### PR TITLE
feat: add OAuth2 client registration endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,6 +45,7 @@ func main() {
 	}
 
 	identityRepository := identity.NewIdentityRepository(awsCfg)
+	clientRepository := oauth2.NewClientRepository(awsCfg)
 
 	keyRepo := keys.NewInMemoryRepository()
 	keyService := keys.NewService(keyRepo)
@@ -57,6 +58,12 @@ func main() {
 	identityHandler := identity.HttpHandler{
 		Service: identity.Service{
 			Repo: identityRepository,
+		},
+	}
+
+	clientHandler := oauth2.ClientHttpHandler{
+		ClientService: oauth2.ClientService{
+			Repo: clientRepository,
 		},
 	}
 
@@ -98,11 +105,11 @@ func main() {
 		ihttp.BarricadeAuthenticationProvider{
 			AuthenticationService: authNService,
 		},
-		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize"}...)
+		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "POST /v1/oauth2/clients", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize"}...)
 
 	httpServer := xhttp.Server{
 		Addr:     ":8080",
-		Handlers: []xhttp.RouteHandler{&identityHandler, &authNHandler, &infrastructure.HealthHttpHandler{}, &jwksHandler, &authorizeHandler},
+		Handlers: []xhttp.RouteHandler{&identityHandler, &clientHandler, &authNHandler, &infrastructure.HealthHttpHandler{}, &jwksHandler, &authorizeHandler},
 		AuthN:    authenticator,
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -105,7 +105,7 @@ func main() {
 		ihttp.BarricadeAuthenticationProvider{
 			AuthenticationService: authNService,
 		},
-		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "POST /v1/oauth2/clients", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize"}...)
+		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize"}...)
 
 	httpServer := xhttp.Server{
 		Addr:     ":8080",

--- a/internal/oauth2/client.go
+++ b/internal/oauth2/client.go
@@ -1,0 +1,82 @@
+package oauth2
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"golang.org/x/crypto/bcrypt"
+)
+
+type (
+	ClientId     string
+	ClientSecret string
+
+	Client struct {
+		Id          ClientId
+		Name        string
+		Domain      string
+		SecretHash  []byte
+		RedirectURI string
+		CreatedAt   int64
+		UpdatedAt   int64
+	}
+)
+
+func NewClient(name string, domain string, redirectURI string) (*Client, ClientSecret, error) {
+	if name == "" {
+		return nil, "", ErrClientEmptyName
+	}
+	if domain == "" {
+		return nil, "", ErrClientEmptyDomain
+	}
+	if redirectURI == "" {
+		return nil, "", ErrClientEmptyRedirectURI
+	}
+
+	parsedURI, err := url.ParseRequestURI(redirectURI)
+	if err != nil {
+		return nil, "", ErrClientInvalidRedirectURI
+	}
+
+	if !isRedirectDomainMatch(parsedURI.Hostname(), domain) {
+		return nil, "", ErrClientRedirectURIDomainMismatch
+	}
+
+	rawSecret, err := generateClientSecret()
+	if err != nil {
+		return nil, "", err
+	}
+
+	hash, err := bcrypt.GenerateFromPassword([]byte(rawSecret), 14)
+	if err != nil {
+		return nil, "", err
+	}
+
+	createdAt := time.Now().UnixMilli()
+
+	return &Client{
+		Id:          ClientId(uuid.Must(uuid.NewV7()).String()),
+		Name:        name,
+		Domain:      domain,
+		SecretHash:  hash,
+		RedirectURI: redirectURI,
+		CreatedAt:   createdAt,
+		UpdatedAt:   createdAt,
+	}, ClientSecret(rawSecret), nil
+}
+
+func generateClientSecret() (ClientSecret, error) {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return ClientSecret(hex.EncodeToString(b)), nil
+}
+
+func isRedirectDomainMatch(host string, domain string) bool {
+	return host == domain || strings.HasSuffix(host, "."+domain)
+}

--- a/internal/oauth2/client.go
+++ b/internal/oauth2/client.go
@@ -17,6 +17,7 @@ type (
 
 	Client struct {
 		Id          ClientId
+		OwnerId     string
 		Name        string
 		Domain      string
 		SecretHash  []byte
@@ -26,7 +27,10 @@ type (
 	}
 )
 
-func NewClient(name string, domain string, redirectURI string) (*Client, ClientSecret, error) {
+func NewClient(ownerId string, name string, domain string, redirectURI string) (*Client, ClientSecret, error) {
+	if ownerId == "" {
+		return nil, "", ErrClientEmptyOwnerId
+	}
 	if name == "" {
 		return nil, "", ErrClientEmptyName
 	}
@@ -60,6 +64,7 @@ func NewClient(name string, domain string, redirectURI string) (*Client, ClientS
 
 	return &Client{
 		Id:          ClientId(uuid.Must(uuid.NewV7()).String()),
+		OwnerId:     ownerId,
 		Name:        name,
 		Domain:      domain,
 		SecretHash:  hash,

--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -1,0 +1,73 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"net/http"
+
+	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
+)
+
+type registerClientRequest struct {
+	Name        string `json:"name"`
+	Domain      string `json:"domain"`
+	RedirectURI string `json:"redirectURI"`
+}
+
+type registerClientResponse struct {
+	ClientId     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+type ClientHttpHandler struct {
+	ClientService ClientService
+}
+
+func (h *ClientHttpHandler) RegisterRoutes(router *xhttp.Router) {
+	router.RegisterHandler("POST /v1/oauth2/clients", h.Register)
+}
+
+func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) error {
+	var request registerClientRequest
+
+	err := json.NewDecoder(r.Body).Decode(&request)
+	if err != nil {
+		return xhttp.NewError("request does not satisfy required schema", http.StatusBadRequest)
+	}
+
+	result, err := h.ClientService.Register(r.Context(), RegisterClientParams{
+		Name:        request.Name,
+		Domain:      request.Domain,
+		RedirectURI: request.RedirectURI,
+	})
+	if err != nil {
+		return mapClientError(r.Context(), err)
+	}
+
+	return xhttp.WriteResponse(w, http.StatusCreated, registerClientResponse{
+		ClientId:     string(result.Client.Id),
+		ClientSecret: string(result.ClientSecret),
+	})
+}
+
+func mapClientError(ctx context.Context, err error) error {
+	switch {
+	case errors.Is(err, ErrClientEmptyName):
+		return xhttp.NewError("name is required", http.StatusBadRequest)
+	case errors.Is(err, ErrClientEmptyDomain):
+		return xhttp.NewError("domain is required", http.StatusBadRequest)
+	case errors.Is(err, ErrClientEmptyRedirectURI):
+		return xhttp.NewError("redirectURI is required", http.StatusBadRequest)
+	case errors.Is(err, ErrClientInvalidRedirectURI):
+		return xhttp.NewError("redirectURI is not a valid URL", http.StatusBadRequest)
+	case errors.Is(err, ErrClientRedirectURIDomainMismatch):
+		return xhttp.NewError("redirectURI domain does not match client domain", http.StatusBadRequest)
+	case errors.Is(err, ErrClientNotFound):
+		return xhttp.NewError("client not found", http.StatusNotFound)
+	default:
+		slog.ErrorContext(ctx, "client service error", "error", err)
+		return xhttp.NewError("unable to register client", http.StatusInternalServerError)
+	}
+}

--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -30,6 +30,11 @@ func (h *ClientHttpHandler) RegisterRoutes(router *xhttp.Router) {
 }
 
 func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) error {
+	ownerId, ok := r.Context().Value(xhttp.UserId).(string)
+	if !ok || ownerId == "" {
+		return xhttp.NewError("unauthorized", http.StatusUnauthorized)
+	}
+
 	var request registerClientRequest
 
 	err := json.NewDecoder(r.Body).Decode(&request)
@@ -38,6 +43,7 @@ func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) err
 	}
 
 	result, err := h.ClientService.Register(r.Context(), RegisterClientParams{
+		OwnerId:     ownerId,
 		Name:        request.Name,
 		Domain:      request.Domain,
 		RedirectURI: request.RedirectURI,
@@ -54,6 +60,8 @@ func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) err
 
 func mapClientError(ctx context.Context, err error) error {
 	switch {
+	case errors.Is(err, ErrClientEmptyOwnerId):
+		return xhttp.NewError("unauthorized", http.StatusUnauthorized)
 	case errors.Is(err, ErrClientEmptyName):
 		return xhttp.NewError("name is required", http.StatusBadRequest)
 	case errors.Is(err, ErrClientEmptyDomain):

--- a/internal/oauth2/client_repository.go
+++ b/internal/oauth2/client_repository.go
@@ -1,0 +1,103 @@
+package oauth2
+
+import (
+	"context"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+)
+
+type clientDDB struct {
+	Id          string `dynamodbav:"id"`
+	Type        string `dynamodbav:"type"`
+	Name        string `dynamodbav:"name"`
+	Domain      string `dynamodbav:"domain"`
+	SecretHash  []byte `dynamodbav:"secret"`
+	RedirectURI string `dynamodbav:"redirectURI"`
+	CreatedAt   int64  `dynamodbav:"createdAt"`
+	UpdatedAt   int64  `dynamodbav:"updatedAt"`
+}
+
+func convertClientToDB(c *Client) *clientDDB {
+	return &clientDDB{
+		Id:          string(c.Id),
+		Type:        "oauth-client",
+		Name:        c.Name,
+		Domain:      c.Domain,
+		SecretHash:  c.SecretHash,
+		RedirectURI: c.RedirectURI,
+		CreatedAt:   c.CreatedAt,
+		UpdatedAt:   c.UpdatedAt,
+	}
+}
+
+func convertClientFromDB(db *clientDDB) *Client {
+	return &Client{
+		Id:          ClientId(db.Id),
+		Name:        db.Name,
+		Domain:      db.Domain,
+		SecretHash:  db.SecretHash,
+		RedirectURI: db.RedirectURI,
+		CreatedAt:   db.CreatedAt,
+		UpdatedAt:   db.UpdatedAt,
+	}
+}
+
+func clientKey(id ClientId) map[string]types.AttributeValue {
+	return map[string]types.AttributeValue{
+		"id":   &types.AttributeValueMemberS{Value: string(id)},
+		"type": &types.AttributeValueMemberS{Value: "oauth-client"},
+	}
+}
+
+type DynamoDBClientRepository struct {
+	Client *dynamodb.Client
+	Table  *string
+}
+
+func NewClientRepository(cfg aws.Config) *DynamoDBClientRepository {
+	return &DynamoDBClientRepository{
+		Client: dynamodb.NewFromConfig(cfg),
+		Table:  aws.String(os.Getenv("CLIENT_TABLE_NAME")),
+	}
+}
+
+func (r *DynamoDBClientRepository) Save(ctx context.Context, c *Client) error {
+	item, err := attributevalue.MarshalMap(convertClientToDB(c))
+	if err != nil {
+		return err
+	}
+
+	_, err = r.Client.PutItem(ctx, &dynamodb.PutItemInput{
+		TableName: r.Table,
+		Item:      item,
+	})
+
+	return err
+}
+
+func (r *DynamoDBClientRepository) FindById(ctx context.Context, id ClientId) (*Client, error) {
+	output, err := r.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      r.Table,
+		ConsistentRead: aws.Bool(false),
+		Key:            clientKey(id),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(output.Item) == 0 {
+		return nil, ErrClientNotFound
+	}
+
+	var dbEntity clientDDB
+	err = attributevalue.UnmarshalMap(output.Item, &dbEntity)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertClientFromDB(&dbEntity), nil
+}

--- a/internal/oauth2/client_repository.go
+++ b/internal/oauth2/client_repository.go
@@ -11,32 +11,37 @@ import (
 )
 
 type clientDDB struct {
-	Id          string `dynamodbav:"id"`
-	Type        string `dynamodbav:"type"`
-	Name        string `dynamodbav:"name"`
-	Domain      string `dynamodbav:"domain"`
-	SecretHash  []byte `dynamodbav:"secret"`
-	RedirectURI string `dynamodbav:"redirectURI"`
-	CreatedAt   int64  `dynamodbav:"createdAt"`
-	UpdatedAt   int64  `dynamodbav:"updatedAt"`
+	Id                string `dynamodbav:"id"`
+	Type              string `dynamodbav:"type"`
+	SecondaryLookup   string `dynamodbav:"secondary-lookup"`
+	SecondaryLookupSk string `dynamodbav:"secondary-lookup-sk"`
+	Name              string `dynamodbav:"name"`
+	Domain            string `dynamodbav:"domain"`
+	SecretHash        []byte `dynamodbav:"secret"`
+	RedirectURI       string `dynamodbav:"redirectURI"`
+	CreatedAt         int64  `dynamodbav:"createdAt"`
+	UpdatedAt         int64  `dynamodbav:"updatedAt"`
 }
 
 func convertClientToDB(c *Client) *clientDDB {
 	return &clientDDB{
-		Id:          string(c.Id),
-		Type:        "oauth-client",
-		Name:        c.Name,
-		Domain:      c.Domain,
-		SecretHash:  c.SecretHash,
-		RedirectURI: c.RedirectURI,
-		CreatedAt:   c.CreatedAt,
-		UpdatedAt:   c.UpdatedAt,
+		Id:                string(c.Id),
+		Type:              "oauth-client",
+		SecondaryLookup:   c.OwnerId,
+		SecondaryLookupSk: "oauth-client",
+		Name:              c.Name,
+		Domain:            c.Domain,
+		SecretHash:        c.SecretHash,
+		RedirectURI:       c.RedirectURI,
+		CreatedAt:         c.CreatedAt,
+		UpdatedAt:         c.UpdatedAt,
 	}
 }
 
 func convertClientFromDB(db *clientDDB) *Client {
 	return &Client{
 		Id:          ClientId(db.Id),
+		OwnerId:     db.SecondaryLookup,
 		Name:        db.Name,
 		Domain:      db.Domain,
 		SecretHash:  db.SecretHash,

--- a/internal/oauth2/client_service.go
+++ b/internal/oauth2/client_service.go
@@ -1,0 +1,44 @@
+package oauth2
+
+import "context"
+
+type ClientRepository interface {
+	Save(ctx context.Context, client *Client) error
+	FindById(ctx context.Context, id ClientId) (*Client, error)
+}
+
+type RegisterClientParams struct {
+	Name        string
+	Domain      string
+	RedirectURI string
+}
+
+type RegisterClientResult struct {
+	Client       *Client
+	ClientSecret ClientSecret
+}
+
+type ClientService struct {
+	Repo ClientRepository
+}
+
+func (s *ClientService) Register(ctx context.Context, params RegisterClientParams) (*RegisterClientResult, error) {
+	c, secret, err := NewClient(params.Name, params.Domain, params.RedirectURI)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.Repo.Save(ctx, c)
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegisterClientResult{
+		Client:       c,
+		ClientSecret: secret,
+	}, nil
+}
+
+func (s *ClientService) FindById(ctx context.Context, id ClientId) (*Client, error) {
+	return s.Repo.FindById(ctx, id)
+}

--- a/internal/oauth2/client_service.go
+++ b/internal/oauth2/client_service.go
@@ -8,6 +8,7 @@ type ClientRepository interface {
 }
 
 type RegisterClientParams struct {
+	OwnerId     string
 	Name        string
 	Domain      string
 	RedirectURI string
@@ -23,7 +24,7 @@ type ClientService struct {
 }
 
 func (s *ClientService) Register(ctx context.Context, params RegisterClientParams) (*RegisterClientResult, error) {
-	c, secret, err := NewClient(params.Name, params.Domain, params.RedirectURI)
+	c, secret, err := NewClient(params.OwnerId, params.Name, params.Domain, params.RedirectURI)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -10,6 +10,7 @@ var (
 	ErrServerError                     = errors.New("server error")
 	ErrLoginRequired                   = errors.New("login required")
 	ErrClientNotFound                  = errors.New("client not found")
+	ErrClientEmptyOwnerId              = errors.New("client owner id cannot be empty")
 	ErrClientEmptyName                 = errors.New("client name cannot be empty")
 	ErrClientEmptyDomain               = errors.New("client domain cannot be empty")
 	ErrClientEmptyRedirectURI          = errors.New("client redirect URI cannot be empty")

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -3,10 +3,16 @@ package oauth2
 import "errors"
 
 var (
-	ErrInvalidRequest          = errors.New("invalid request")
-	ErrUnsupportedResponseType = errors.New("unsupported response type")
-	ErrInvalidScope            = errors.New("invalid scope")
-	ErrInvalidRedirectURI      = errors.New("invalid redirect uri")
-	ErrServerError             = errors.New("server error")
-	ErrLoginRequired           = errors.New("login required")
+	ErrInvalidRequest                  = errors.New("invalid request")
+	ErrUnsupportedResponseType         = errors.New("unsupported response type")
+	ErrInvalidScope                    = errors.New("invalid scope")
+	ErrInvalidRedirectURI              = errors.New("invalid redirect uri")
+	ErrServerError                     = errors.New("server error")
+	ErrLoginRequired                   = errors.New("login required")
+	ErrClientNotFound                  = errors.New("client not found")
+	ErrClientEmptyName                 = errors.New("client name cannot be empty")
+	ErrClientEmptyDomain               = errors.New("client domain cannot be empty")
+	ErrClientEmptyRedirectURI          = errors.New("client redirect URI cannot be empty")
+	ErrClientInvalidRedirectURI        = errors.New("client redirect URI is not a valid URL")
+	ErrClientRedirectURIDomainMismatch = errors.New("client redirect URI domain does not match client domain")
 )

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -1,0 +1,153 @@
+package test
+
+import (
+	"barricade/internal/oauth2"
+	"context"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/bcrypt"
+)
+
+const (
+	TEST_CLIENT_NAME         = "test-app"
+	TEST_CLIENT_DOMAIN       = "example.com"
+	TEST_CLIENT_REDIRECT_URI = "https://example.com/callback"
+)
+
+type clientModule struct {
+	service    oauth2.ClientService
+	repository oauth2.ClientRepository
+}
+
+func setupClientModule(t *testing.T) *clientModule {
+	entitiesTable := dynamodb.CreateTableInput{
+		TableName: aws.String("test_entities_table"),
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("id"),
+				KeyType:       types.KeyTypeHash,
+			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("id"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	}
+
+	ddbClient := setupDynamo(t, entitiesTable)
+
+	clientRepo := &oauth2.DynamoDBClientRepository{
+		Client: ddbClient,
+		Table:  aws.String("test_entities_table"),
+	}
+
+	return &clientModule{
+		service:    oauth2.ClientService{Repo: clientRepo},
+		repository: clientRepo,
+	}
+}
+
+func TestClientRegisterInputValidation(t *testing.T) {
+	module := setupClientModule(t)
+
+	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        "",
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.ErrorIs(t, err, oauth2.ErrClientEmptyName)
+
+	_, err = module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        TEST_CLIENT_NAME,
+		Domain:      "",
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.ErrorIs(t, err, oauth2.ErrClientEmptyDomain)
+
+	_, err = module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: "",
+	})
+	assert.ErrorIs(t, err, oauth2.ErrClientEmptyRedirectURI)
+}
+
+func TestClientRegisterInvalidRedirectURI(t *testing.T) {
+	module := setupClientModule(t)
+
+	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: "not-a-url",
+	})
+	assert.ErrorIs(t, err, oauth2.ErrClientInvalidRedirectURI)
+}
+
+func TestClientRegisterRedirectURIDomainMismatch(t *testing.T) {
+	module := setupClientModule(t)
+
+	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: "https://other.com/callback",
+	})
+	assert.ErrorIs(t, err, oauth2.ErrClientRedirectURIDomainMismatch)
+}
+
+func TestClientRegisterSubdomainAllowed(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: "https://sub.example.com/callback",
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result.Client.Id)
+}
+
+func TestClientRegisterHappyPath(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.NoError(t, err)
+
+	assert.Equal(t, TEST_CLIENT_NAME, result.Client.Name)
+	assert.Equal(t, TEST_CLIENT_DOMAIN, result.Client.Domain)
+	assert.Equal(t, TEST_CLIENT_REDIRECT_URI, result.Client.RedirectURI)
+	assert.NotEmpty(t, result.Client.Id)
+	assert.NotEmpty(t, result.ClientSecret)
+	assert.Nil(t, bcrypt.CompareHashAndPassword(result.Client.SecretHash, []byte(result.ClientSecret)))
+	assert.NotEmpty(t, result.Client.CreatedAt)
+	assert.NotEmpty(t, result.Client.UpdatedAt)
+
+	stored, err := module.repository.FindById(context.Background(), result.Client.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, result.Client, stored)
+}
+
+func TestClientFindByIdNotFound(t *testing.T) {
+	module := setupClientModule(t)
+
+	_, err := module.repository.FindById(context.Background(), oauth2.ClientId("nonexistent"))
+	assert.ErrorIs(t, err, oauth2.ErrClientNotFound)
+}

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	TEST_CLIENT_OWNER_ID    = "01234567-89ab-cdef-0123-456789abcdef"
 	TEST_CLIENT_NAME         = "test-app"
 	TEST_CLIENT_DOMAIN       = "example.com"
 	TEST_CLIENT_REDIRECT_URI = "https://example.com/callback"
@@ -62,10 +63,23 @@ func setupClientModule(t *testing.T) *clientModule {
 	}
 }
 
+func TestClientRegisterEmptyOwnerId(t *testing.T) {
+	module := setupClientModule(t)
+
+	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     "",
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.ErrorIs(t, err, oauth2.ErrClientEmptyOwnerId)
+}
+
 func TestClientRegisterInputValidation(t *testing.T) {
 	module := setupClientModule(t)
 
 	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        "",
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
@@ -73,6 +87,7 @@ func TestClientRegisterInputValidation(t *testing.T) {
 	assert.ErrorIs(t, err, oauth2.ErrClientEmptyName)
 
 	_, err = module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        TEST_CLIENT_NAME,
 		Domain:      "",
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
@@ -80,6 +95,7 @@ func TestClientRegisterInputValidation(t *testing.T) {
 	assert.ErrorIs(t, err, oauth2.ErrClientEmptyDomain)
 
 	_, err = module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: "",
@@ -91,6 +107,7 @@ func TestClientRegisterInvalidRedirectURI(t *testing.T) {
 	module := setupClientModule(t)
 
 	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: "not-a-url",
@@ -102,6 +119,7 @@ func TestClientRegisterRedirectURIDomainMismatch(t *testing.T) {
 	module := setupClientModule(t)
 
 	_, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: "https://other.com/callback",
@@ -113,6 +131,7 @@ func TestClientRegisterSubdomainAllowed(t *testing.T) {
 	module := setupClientModule(t)
 
 	result, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: "https://sub.example.com/callback",
@@ -125,6 +144,7 @@ func TestClientRegisterHappyPath(t *testing.T) {
 	module := setupClientModule(t)
 
 	result, err := module.service.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
@@ -132,6 +152,7 @@ func TestClientRegisterHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, TEST_CLIENT_NAME, result.Client.Name)
+	assert.Equal(t, TEST_CLIENT_OWNER_ID, result.Client.OwnerId)
 	assert.Equal(t, TEST_CLIENT_DOMAIN, result.Client.Domain)
 	assert.Equal(t, TEST_CLIENT_REDIRECT_URI, result.Client.RedirectURI)
 	assert.NotEmpty(t, result.Client.Id)


### PR DESCRIPTION
Add OAuth2 client registration endpoint (`POST /v1/oauth2/clients`) for registering OIDC clients.

- Auto-generated client ID (UUIDv7) and secret (64-char hex, bcrypt-hashed for storage)
- Redirect URI validation: must be valid URL whose host matches the client domain (subdomains allowed)
- Requires authentication — owner ID extracted from session context, stored as `OwnerId`
- Owner propagated to DynamoDB GSI (`secondary-lookup` + `secondary-lookup-sk`) for queries by owner
- Route removed from unauthenticated skip list
- `rand.Read` error propagated instead of silently ignored
- `ErrClientNotFound` mapped to 404 in handler

Verified: `go build ./...`, `go vet ./...`, `go test ./...` all pass.