### PR TITLE
fix: validate client redirect URI and redirect param errors per OAuth2 spec

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,10 +61,10 @@ func main() {
 		},
 	}
 
+	clientService := oauth2.ClientService{Repo: clientRepository}
+
 	clientHandler := oauth2.ClientHttpHandler{
-		ClientService: oauth2.ClientService{
-			Repo: clientRepository,
-		},
+		ClientService: clientService,
 	}
 
 	sessionService := authentication.SessionService{
@@ -89,16 +89,16 @@ func main() {
 
 	authorizeService := oauth2.AuthorizeService{
 		IdentityStore: identityRepository,
+		ClientStore:   clientRepository,
 		KeyService:    keyService,
 		Issuer:        cfg.IssuerURL,
 		TokenExpiry:   cfg.TokenExpiryMinutes,
 	}
 
 	authorizeHandler := oauth2.HttpHandler{
-		Service:            &authorizeService,
-		AuthService:        &authNService,
-		LoginURL:           cfg.LoginURL,
-		DefaultRedirectURI: cfg.IssuerURL,
+		Service:     &authorizeService,
+		AuthService: &authNService,
+		LoginURL:    cfg.LoginURL,
 	}
 
 	authenticator := xhttp.NewAuthenticator(

--- a/internal/oauth2/authorize_handler.go
+++ b/internal/oauth2/authorize_handler.go
@@ -14,10 +14,9 @@ import (
 )
 
 type HttpHandler struct {
-	Service            *AuthorizeService
-	AuthService        *authentication.Service
-	LoginURL           string
-	DefaultRedirectURI string
+	Service     *AuthorizeService
+	AuthService *authentication.Service
+	LoginURL    string
 }
 
 func (h *HttpHandler) RegisterRoutes(router *xhttp.Router) {
@@ -31,17 +30,16 @@ func (h *HttpHandler) Authorize(w http.ResponseWriter, r *http.Request) error {
 		ResponseType: r.URL.Query().Get("response_type"),
 		ClientId:     r.URL.Query().Get("client_id"),
 		Scope:        r.URL.Query().Get("scope"),
+		RedirectURI:  r.URL.Query().Get("redirect_uri"),
 	}
 
-	redirectURI := r.URL.Query().Get("redirect_uri")
-	if redirectURI == "" {
-		redirectURI = h.DefaultRedirectURI
+	if params.ClientId == "" {
+		return xhttp.NewError("invalid request: missing client_id", http.StatusBadRequest)
 	}
 
-	if err := validateRedirectURI(redirectURI); err != nil {
-		redirectURL := buildErrorRedirectURL(redirectURI, mapErrorToCode(err), err.Error())
-		http.Redirect(w, r, redirectURL, http.StatusFound)
-		return nil
+	_, redirectURI, err := h.Service.ValidateClientRedirect(ctx, params)
+	if err != nil {
+		return mapAuthorizeError(err)
 	}
 
 	if err := h.Service.Validate(params); err != nil {
@@ -99,16 +97,6 @@ func (h *HttpHandler) buildLoginRedirectURL(r *http.Request) string {
 	return u.String()
 }
 
-func validateRedirectURI(redirectURI string) error {
-	if redirectURI == "" {
-		return ErrInvalidRequest
-	}
-	if _, err := url.ParseRequestURI(redirectURI); err != nil {
-		return ErrInvalidRedirectURI
-	}
-	return nil
-}
-
 func buildSuccessRedirectURL(redirectURI string, result *AuthorizationResult, tokenExpiry int) string {
 	u, err := url.Parse(redirectURI)
 	if err != nil {
@@ -154,5 +142,20 @@ func mapErrorToCode(err error) string {
 		return "invalid_request"
 	default:
 		return "server_error"
+	}
+}
+
+func mapAuthorizeError(err error) error {
+	switch {
+	case errors.Is(err, ErrInvalidRequest), errors.Is(err, ErrUnsupportedResponseType),
+		errors.Is(err, ErrInvalidScope), errors.Is(err, ErrInvalidRedirectURI):
+		return xhttp.NewError(mapErrorToCode(err), http.StatusBadRequest)
+	case errors.Is(err, ErrUnauthorizedClient):
+		return xhttp.NewError("unauthorized client", http.StatusUnauthorized)
+	case errors.Is(err, ErrRedirectURIMismatch):
+		return xhttp.NewError("redirect uri mismatch", http.StatusBadRequest)
+	default:
+		slog.Error("authorize error", "error", err)
+		return xhttp.NewError("server_error", http.StatusInternalServerError)
 	}
 }

--- a/internal/oauth2/authorize_handler_test.go
+++ b/internal/oauth2/authorize_handler_test.go
@@ -16,6 +16,18 @@ func (m *mockIdentityRepository) FindById(ctx context.Context, id identity.Id) (
 	return m.findByIdFunc(ctx, id)
 }
 
+type mockClientRepository struct {
+	findByIdFunc func(ctx context.Context, id ClientId) (*Client, error)
+}
+
+func (m *mockClientRepository) Save(ctx context.Context, client *Client) error {
+	return nil
+}
+
+func (m *mockClientRepository) FindById(ctx context.Context, id ClientId) (*Client, error) {
+	return m.findByIdFunc(ctx, id)
+}
+
 func TestAuthorizeServiceValidateMissingResponseType(t *testing.T) {
 	service := &AuthorizeService{}
 
@@ -79,6 +91,120 @@ func TestAuthorizeServiceValidateHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestValidateClientRedirectClientNotFound(t *testing.T) {
+	clientRepo := &mockClientRepository{
+		findByIdFunc: func(ctx context.Context, id ClientId) (*Client, error) {
+			return nil, ErrClientNotFound
+		},
+	}
+
+	service := &AuthorizeService{ClientStore: clientRepo}
+
+	params := AuthorizationParams{
+		ClientId:    "unknown-client",
+		RedirectURI: "https://example.com/callback",
+	}
+
+	_, _, err := service.ValidateClientRedirect(context.Background(), params)
+	assert.ErrorIs(t, err, ErrUnauthorizedClient)
+}
+
+func TestValidateClientRedirectRedirectURIMismatch(t *testing.T) {
+	clientRepo := &mockClientRepository{
+		findByIdFunc: func(ctx context.Context, id ClientId) (*Client, error) {
+			return &Client{Id: id, Domain: "example.com", RedirectURI: "https://example.com/callback"}, nil
+		},
+	}
+
+	service := &AuthorizeService{ClientStore: clientRepo}
+
+	params := AuthorizationParams{
+		ClientId:    "test-client",
+		RedirectURI: "https://evil.com/callback",
+	}
+
+	_, _, err := service.ValidateClientRedirect(context.Background(), params)
+	assert.ErrorIs(t, err, ErrRedirectURIMismatch)
+}
+
+func TestValidateClientRedirectInvalidRedirectURI(t *testing.T) {
+	clientRepo := &mockClientRepository{
+		findByIdFunc: func(ctx context.Context, id ClientId) (*Client, error) {
+			return &Client{Id: id, Domain: "example.com", RedirectURI: "https://example.com/callback"}, nil
+		},
+	}
+
+	service := &AuthorizeService{ClientStore: clientRepo}
+
+	params := AuthorizationParams{
+		ClientId:    "test-client",
+		RedirectURI: "://invalid-url",
+	}
+
+	_, _, err := service.ValidateClientRedirect(context.Background(), params)
+	assert.ErrorIs(t, err, ErrInvalidRedirectURI)
+}
+
+func TestValidateClientRedirectUsesClientRedirectURIFallback(t *testing.T) {
+	clientRepo := &mockClientRepository{
+		findByIdFunc: func(ctx context.Context, id ClientId) (*Client, error) {
+			return &Client{Id: id, Domain: "example.com", RedirectURI: "https://example.com/callback"}, nil
+		},
+	}
+
+	service := &AuthorizeService{ClientStore: clientRepo}
+
+	params := AuthorizationParams{
+		ClientId:    "test-client",
+		RedirectURI: "",
+	}
+
+	client, redirectURI, err := service.ValidateClientRedirect(context.Background(), params)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-client", string(client.Id))
+	assert.Equal(t, "https://example.com/callback", redirectURI)
+}
+
+func TestValidateClientRedirectSubdomainAllowed(t *testing.T) {
+	clientRepo := &mockClientRepository{
+		findByIdFunc: func(ctx context.Context, id ClientId) (*Client, error) {
+			return &Client{Id: id, Domain: "example.com", RedirectURI: "https://example.com/callback"}, nil
+		},
+	}
+
+	service := &AuthorizeService{ClientStore: clientRepo}
+
+	params := AuthorizationParams{
+		ClientId:    "test-client",
+		RedirectURI: "https://sub.example.com/callback",
+	}
+
+	client, redirectURI, err := service.ValidateClientRedirect(context.Background(), params)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-client", string(client.Id))
+	assert.Equal(t, "https://sub.example.com/callback", redirectURI)
+}
+
+func TestValidateClientRedirectHappyPath(t *testing.T) {
+	clientRepo := &mockClientRepository{
+		findByIdFunc: func(ctx context.Context, id ClientId) (*Client, error) {
+			return &Client{Id: id, Domain: "example.com", RedirectURI: "https://example.com/callback"}, nil
+		},
+	}
+
+	service := &AuthorizeService{ClientStore: clientRepo}
+
+	params := AuthorizationParams{
+		ClientId:    "test-client",
+		RedirectURI: "https://example.com/callback",
+	}
+
+	client, redirectURI, err := service.ValidateClientRedirect(context.Background(), params)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-client", string(client.Id))
+	assert.Equal(t, "https://example.com/callback", redirectURI)
+}
+
 func TestBuildSuccessRedirectURL(t *testing.T) {
 	result := &AuthorizationResult{
 		IDToken: "test-id-token",
@@ -107,16 +233,6 @@ func TestBuildErrorRedirectURLEmptyDescription(t *testing.T) {
 
 	assert.Contains(t, redirectURL, "error=invalid_scope")
 	assert.NotContains(t, redirectURL, "error_description")
-}
-
-func TestValidateRedirectURIEmpty(t *testing.T) {
-	err := validateRedirectURI("")
-	assert.ErrorIs(t, err, ErrInvalidRequest)
-}
-
-func TestValidateRedirectURIInvalid(t *testing.T) {
-	err := validateRedirectURI("://invalid-url")
-	assert.ErrorIs(t, err, ErrInvalidRedirectURI)
 }
 
 func TestBuildSuccessRedirectURLInvalidURI(t *testing.T) {

--- a/internal/oauth2/authorize_service.go
+++ b/internal/oauth2/authorize_service.go
@@ -5,6 +5,8 @@ import (
 	"barricade/internal/keys"
 	"barricade/internal/oidc"
 	"context"
+	"errors"
+	"net/url"
 	"strings"
 )
 
@@ -27,6 +29,7 @@ type (
 		ResponseType string
 		ClientId     string
 		Scope        string
+		RedirectURI  string
 	}
 
 	AuthorizationResult struct {
@@ -35,11 +38,38 @@ type (
 
 	AuthorizeService struct {
 		IdentityStore IdentityRepository
+		ClientStore   ClientRepository
 		KeyService    *keys.Service
 		Issuer        string
 		TokenExpiry   int
 	}
 )
+
+func (s *AuthorizeService) ValidateClientRedirect(ctx context.Context, params AuthorizationParams) (*Client, string, error) {
+	client, err := s.ClientStore.FindById(ctx, ClientId(params.ClientId))
+	if err != nil {
+		if errors.Is(err, ErrClientNotFound) {
+			return nil, "", ErrUnauthorizedClient
+		}
+		return nil, "", err
+	}
+
+	redirectURI := params.RedirectURI
+	if redirectURI == "" {
+		redirectURI = client.RedirectURI
+	}
+
+	parsedURI, err := url.ParseRequestURI(redirectURI)
+	if err != nil {
+		return nil, "", ErrInvalidRedirectURI
+	}
+
+	if !isRedirectDomainMatch(parsedURI.Hostname(), client.Domain) {
+		return nil, "", ErrRedirectURIMismatch
+	}
+
+	return client, redirectURI, nil
+}
 
 func (s *AuthorizeService) Validate(params AuthorizationParams) error {
 	if params.ResponseType == "" {

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -9,6 +9,8 @@ var (
 	ErrInvalidRedirectURI              = errors.New("invalid redirect uri")
 	ErrServerError                     = errors.New("server error")
 	ErrLoginRequired                   = errors.New("login required")
+	ErrUnauthorizedClient              = errors.New("unauthorized client")
+	ErrRedirectURIMismatch             = errors.New("redirect uri mismatch")
 	ErrClientNotFound                  = errors.New("client not found")
 	ErrClientEmptyOwnerId              = errors.New("client owner id cannot be empty")
 	ErrClientEmptyName                 = errors.New("client name cannot be empty")

--- a/test/oauth2_authorize_test.go
+++ b/test/oauth2_authorize_test.go
@@ -20,9 +20,11 @@ type oauth2Module struct {
 	authorizeHandler   *oauth2.HttpHandler
 	sessionService     authentication.SessionService
 	identityService    identity.Service
+	clientService      oauth2.ClientService
 	keyService         *keys.Service
 	identityRepository identity.Repository
 	sessionRepository  authentication.SessionRepository
+	clientRepository   oauth2.ClientRepository
 }
 
 func setupOAuth2Module(t *testing.T) *oauth2Module {
@@ -105,7 +107,32 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 		BillingMode: types.BillingModePayPerRequest,
 	}
 
-	client := setupDynamo(t, sessionTable, identityTable)
+	entitiesTable := dynamodb.CreateTableInput{
+		TableName: aws.String("test_entities_table"),
+		KeySchema: []types.KeySchemaElement{
+			{
+				AttributeName: aws.String("id"),
+				KeyType:       types.KeyTypeHash,
+			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
+		},
+		AttributeDefinitions: []types.AttributeDefinition{
+			{
+				AttributeName: aws.String("id"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		BillingMode: types.BillingModePayPerRequest,
+	}
+
+	client := setupDynamo(t, sessionTable, identityTable, entitiesTable)
 
 	identityStore := &identity.DynamoDBIdentityRepository{
 		Client:    client,
@@ -131,6 +158,13 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 		},
 	}
 
+	clientRepository := &oauth2.DynamoDBClientRepository{
+		Client: client,
+		Table:  aws.String("test_entities_table"),
+	}
+
+	clientService := oauth2.ClientService{Repo: clientRepository}
+
 	keyRepo := keys.NewInMemoryRepository()
 	keyService := keys.NewService(keyRepo)
 
@@ -139,6 +173,7 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 
 	authorizeService := &oauth2.AuthorizeService{
 		IdentityStore: identityStore,
+		ClientStore:   clientRepository,
 		KeyService:    keyService,
 		Issuer:        "https://test.issuer.com",
 		TokenExpiry:   5,
@@ -150,10 +185,9 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 	}
 
 	authorizeHandler := &oauth2.HttpHandler{
-		Service:            authorizeService,
-		AuthService:        authService,
-		LoginURL:           "https://auth.test.com/login",
-		DefaultRedirectURI: "https://auth.test.com",
+		Service:     authorizeService,
+		AuthService: authService,
+		LoginURL:    "https://auth.test.com/login",
 	}
 
 	return &oauth2Module{
@@ -161,9 +195,11 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 		authorizeHandler:   authorizeHandler,
 		sessionService:     sessionService,
 		identityService:    identityService,
+		clientService:      clientService,
 		keyService:         keyService,
 		identityRepository: identityStore,
 		sessionRepository:  sessionStore,
+		clientRepository:   clientRepository,
 	}
 }
 
@@ -224,11 +260,104 @@ func TestAuthorizeServiceAuthorizeHappyPath(t *testing.T) {
 	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
 	assert.NoError(t, err)
 
+	clientResult, err := module.clientService.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     string(ident.Id),
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := module.authorizeService.Authorize(ctx, ident.Id, "test-client")
+	result, err := module.authorizeService.Authorize(ctx, ident.Id, string(clientResult.Client.Id))
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result.IDToken)
 	assert.NotNil(t, result)
+}
+
+func TestValidateClientRedirectUnregisteredClient(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	params := oauth2.AuthorizationParams{
+		ClientId:    "nonexistent-client-id",
+		RedirectURI: "https://example.com/callback",
+	}
+
+	_, _, err := module.authorizeService.ValidateClientRedirect(context.Background(), params)
+	assert.ErrorIs(t, err, oauth2.ErrUnauthorizedClient)
+}
+
+func TestValidateClientRedirectRedirectURIDomainMismatch(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	_, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	params := oauth2.AuthorizationParams{
+		ClientId:    string(clientResult.Client.Id),
+		RedirectURI: "https://evil.com/callback",
+	}
+
+	_, _, err = module.authorizeService.ValidateClientRedirect(context.Background(), params)
+	assert.ErrorIs(t, err, oauth2.ErrRedirectURIMismatch)
+}
+
+func TestValidateClientRedirectUsesRegisteredURIAsFallback(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	_, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	params := oauth2.AuthorizationParams{
+		ClientId:    string(clientResult.Client.Id),
+		RedirectURI: "",
+	}
+
+	client, redirectURI, err := module.authorizeService.ValidateClientRedirect(context.Background(), params)
+	assert.NoError(t, err)
+	assert.Equal(t, clientResult.Client.Id, client.Id)
+	assert.Equal(t, "https://example.com/callback", redirectURI)
+}
+
+func TestValidateClientRedirectSubdomainAllowed(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	_, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), oauth2.RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	params := oauth2.AuthorizationParams{
+		ClientId:    string(clientResult.Client.Id),
+		RedirectURI: "https://sub.example.com/callback",
+	}
+
+	client, redirectURI, err := module.authorizeService.ValidateClientRedirect(context.Background(), params)
+	assert.NoError(t, err)
+	assert.Equal(t, clientResult.Client.Id, client.Id)
+	assert.Equal(t, "https://sub.example.com/callback", redirectURI)
 }


### PR DESCRIPTION
## Summary

- Move redirect URI validation from handler to `AuthorizeService.ValidateClientRedirect`, which looks up the client from DB and validates the redirect URI domain
- Fix handler to validate client/redirect URI **before** params, so that param validation errors (unsupported_response_type, invalid_scope) are redirected to the validated redirect URI per RFC 6749, rather than returned as HTTP errors
- `ValidateClientRedirect` only maps `ErrClientNotFound` → `ErrUnauthorizedClient`; other errors (e.g., DynamoDB failures) are propagated as-is instead of being silently swallowed
- Remove `DefaultRedirectURI` config; when no `redirect_uri` param is provided, fallback to the client's registered `RedirectURI`

## Verification

- Unit tests pass (`go test ./internal/oauth2/...`)
- `go vet` and `go build` pass
- Added tests for `ValidateClientRedirect`: client not found, domain mismatch, invalid URI, registered URI fallback, subdomain allowed
- Added integration tests for client redirect validation scenarios