### PR TITLE
feat: Add sharded-type GSI and GET /v1/oauth2/clients endpoint

### DIFF
--- a/.iac/lib/iac-stack.ts
+++ b/.iac/lib/iac-stack.ts
@@ -30,6 +30,18 @@ export class IacStack extends cdk.Stack {
       },
     });
 
+    entitiesTable.addGlobalSecondaryIndex({
+      indexName: "sharded-type-index",
+      partitionKey: {
+        name: "sharded-type",
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: "id",
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
     const operationalTable = new dynamodb.Table(
       this,
       "OperationalEntitiesTable",

--- a/.iac/test/iac.test.ts
+++ b/.iac/test/iac.test.ts
@@ -70,6 +70,21 @@ describe("IacStack", () => {
         ]),
       });
     });
+
+    it("has the sharded type GSI", () => {
+      template.hasResourceProperties("AWS::DynamoDB::Table", {
+        GlobalSecondaryIndexes: Match.arrayWith([
+          Match.objectLike({
+            IndexName: "sharded-type-index",
+            KeySchema: [
+              { AttributeName: "sharded-type", KeyType: "HASH" },
+              { AttributeName: "id", KeyType: "RANGE" },
+            ],
+            Projection: { ProjectionType: "ALL" },
+          }),
+        ]),
+      });
+    });
   });
 
   describe("OperationalEntitiesTable", () => {

--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -21,12 +21,22 @@ type registerClientResponse struct {
 	ClientSecret string `json:"clientSecret"`
 }
 
+type listClientResponse struct {
+	Id          string `json:"id"`
+	Name        string `json:"name"`
+	Domain      string `json:"domain"`
+	RedirectURI string `json:"redirectURI"`
+	CreatedAt   int64  `json:"createdAt"`
+	UpdatedAt   int64  `json:"updatedAt"`
+}
+
 type ClientHttpHandler struct {
 	ClientService ClientService
 }
 
 func (h *ClientHttpHandler) RegisterRoutes(router *xhttp.Router) {
 	router.RegisterHandler("POST /v1/oauth2/clients", h.Register)
+	router.RegisterHandler("GET /v1/oauth2/clients", h.List)
 }
 
 func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) error {
@@ -56,6 +66,35 @@ func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) err
 		ClientId:     string(result.Client.Id),
 		ClientSecret: string(result.ClientSecret),
 	})
+}
+
+func (h *ClientHttpHandler) List(w http.ResponseWriter, r *http.Request) error {
+	ownerId, ok := r.Context().Value(xhttp.UserId).(string)
+	if !ok || ownerId == "" {
+		return xhttp.NewError("unauthorized", http.StatusUnauthorized)
+	}
+
+	clients, err := h.ClientService.FindAll(r.Context())
+	if err != nil {
+		return mapClientError(r.Context(), err)
+	}
+
+	var response []listClientResponse
+	for _, c := range clients {
+		if c.OwnerId != ownerId {
+			continue
+		}
+		response = append(response, listClientResponse{
+			Id:          string(c.Id),
+			Name:        c.Name,
+			Domain:      c.Domain,
+			RedirectURI: c.RedirectURI,
+			CreatedAt:   c.CreatedAt,
+			UpdatedAt:   c.UpdatedAt,
+		})
+	}
+
+	return xhttp.WriteResponse(w, http.StatusOK, response)
 }
 
 func mapClientError(ctx context.Context, err error) error {

--- a/internal/oauth2/client_repository.go
+++ b/internal/oauth2/client_repository.go
@@ -2,17 +2,23 @@ package oauth2
 
 import (
 	"context"
+	"hash/crc32"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
+	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+const shardCount = 4
+
 type clientDDB struct {
 	Id                string `dynamodbav:"id"`
 	Type              string `dynamodbav:"type"`
+	ShardedType       string `dynamodbav:"sharded-type"`
 	SecondaryLookup   string `dynamodbav:"secondary-lookup"`
 	SecondaryLookupSk string `dynamodbav:"secondary-lookup-sk"`
 	Name              string `dynamodbav:"name"`
@@ -23,10 +29,16 @@ type clientDDB struct {
 	UpdatedAt         int64  `dynamodbav:"updatedAt"`
 }
 
+func computeShard(id ClientId) string {
+	sum := crc32.ChecksumIEEE([]byte(id))
+	return "oauth-client#" + strconv.Itoa(int(sum)%shardCount)
+}
+
 func convertClientToDB(c *Client) *clientDDB {
 	return &clientDDB{
 		Id:                string(c.Id),
 		Type:              "oauth-client",
+		ShardedType:       computeShard(c.Id),
 		SecondaryLookup:   c.OwnerId,
 		SecondaryLookupSk: "oauth-client",
 		Name:              c.Name,
@@ -59,14 +71,16 @@ func clientKey(id ClientId) map[string]types.AttributeValue {
 }
 
 type DynamoDBClientRepository struct {
-	Client *dynamodb.Client
-	Table  *string
+	Client           *dynamodb.Client
+	Table            *string
+	ShardedTypeIndex *string
 }
 
 func NewClientRepository(cfg aws.Config) *DynamoDBClientRepository {
 	return &DynamoDBClientRepository{
-		Client: dynamodb.NewFromConfig(cfg),
-		Table:  aws.String(os.Getenv("CLIENT_TABLE_NAME")),
+		Client:           dynamodb.NewFromConfig(cfg),
+		Table:            aws.String(os.Getenv("CLIENT_TABLE_NAME")),
+		ShardedTypeIndex: aws.String("sharded-type-index"),
 	}
 }
 
@@ -105,4 +119,39 @@ func (r *DynamoDBClientRepository) FindById(ctx context.Context, id ClientId) (*
 	}
 
 	return convertClientFromDB(&dbEntity), nil
+}
+
+func (r *DynamoDBClientRepository) FindAll(ctx context.Context) ([]*Client, error) {
+	var result []*Client
+
+	for i := 0; i < shardCount; i++ {
+		shard := "oauth-client#" + strconv.Itoa(i)
+		keyEx := expression.Key("sharded-type").Equal(expression.Value(shard))
+		expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+		if err != nil {
+			return nil, err
+		}
+
+		output, err := r.Client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 r.Table,
+			IndexName:                 r.ShardedTypeIndex,
+			KeyConditionExpression:    expr.KeyCondition(),
+			ExpressionAttributeNames:  expr.Names(),
+			ExpressionAttributeValues: expr.Values(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range output.Items {
+			var dbEntity clientDDB
+			err = attributevalue.UnmarshalMap(item, &dbEntity)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, convertClientFromDB(&dbEntity))
+		}
+	}
+
+	return result, nil
 }

--- a/internal/oauth2/client_service.go
+++ b/internal/oauth2/client_service.go
@@ -5,6 +5,7 @@ import "context"
 type ClientRepository interface {
 	Save(ctx context.Context, client *Client) error
 	FindById(ctx context.Context, id ClientId) (*Client, error)
+	FindAll(ctx context.Context) ([]*Client, error)
 }
 
 type RegisterClientParams struct {
@@ -42,4 +43,8 @@ func (s *ClientService) Register(ctx context.Context, params RegisterClientParam
 
 func (s *ClientService) FindById(ctx context.Context, id ClientId) (*Client, error) {
 	return s.Repo.FindById(ctx, id)
+}
+
+func (s *ClientService) FindAll(ctx context.Context) ([]*Client, error) {
+	return s.Repo.FindAll(ctx)
 }

--- a/internal/oauth2/client_test.go
+++ b/internal/oauth2/client_test.go
@@ -47,6 +47,28 @@ func setupClientModule(t *testing.T) *clientModule {
 				AttributeName: aws.String("type"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
+			{
+				AttributeName: aws.String("sharded-type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+		},
+		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+			{
+				IndexName: aws.String("sharded-type-index"),
+				KeySchema: []types.KeySchemaElement{
+					{
+						AttributeName: aws.String("sharded-type"),
+						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("id"),
+						KeyType:       types.KeyTypeRange,
+					},
+				},
+				Projection: &types.Projection{
+					ProjectionType: types.ProjectionTypeAll,
+				},
+			},
 		},
 		BillingMode: types.BillingModePayPerRequest,
 	}
@@ -54,8 +76,9 @@ func setupClientModule(t *testing.T) *clientModule {
 	ddbClient := itest.SetupDynamo(t, entitiesTable)
 
 	clientRepo := &DynamoDBClientRepository{
-		Client: ddbClient,
-		Table:  aws.String("test_entities_table"),
+		Client:           ddbClient,
+		Table:            aws.String("test_entities_table"),
+		ShardedTypeIndex: aws.String("sharded-type-index"),
 	}
 
 	return &clientModule{
@@ -172,4 +195,36 @@ func TestClientFindByIdNotFound(t *testing.T) {
 
 	_, err := module.repository.FindById(context.Background(), ClientId("nonexistent"))
 	assert.ErrorIs(t, err, ErrClientNotFound)
+}
+
+func TestClientFindAllHappyPath(t *testing.T) {
+	module := setupClientModule(t)
+
+	_, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "app-1",
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.NoError(t, err)
+
+	_, err = module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "app-2",
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.NoError(t, err)
+
+	_, err = module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     "other-owner",
+		Name:        "app-3",
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+	})
+	assert.NoError(t, err)
+
+	clients, err := module.service.FindAll(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, clients, 3)
 }


### PR DESCRIPTION
Adds a new sharded global secondary index to the entities DynamoDB table so OAuth2 clients can be listed efficiently. Also exposes a new authenticated endpoint to retrieve all clients owned by the current user.

## Changes
- CDK: Added `sharded-type-index` GSI to `entitiesTable` with PK `sharded-type` and SK `id`
- Repository: Added `ShardedType` attribute computed as `oauth-client#<crc32(id) % 4>` to distribute clients across 4 shards
- Repository: Added `FindAll` method that queries all shards sequentially via the new GSI
- Service: Added `FindAll` to `ClientRepository` interface and `ClientService`
- Handler: Added `GET /v1/oauth2/clients` endpoint that returns sanitized client data filtered by authenticated owner
- Tests: Added `TestClientFindAllHappyPath` and updated test table setup to include the new GSI

## Verification
- CDK tests pass (15/15) confirming the new GSI is correctly defined in the CloudFormation template
- OAuth2 Go tests pass including the new `TestClientFindAllHappyPath` which registers 3 clients and asserts all are returned