### PR TITLE
chore: Skip CI workflow on main branch pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,9 @@
 name: ci
 
 on:
- - push
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   ci:


### PR DESCRIPTION
Prevents the CI workflow from running when changes are pushed to `main` (e.g., after merging a pull request). The code is already tested in the PR branch, so running CI again on `main` is redundant.

## Changes
- Added `branches-ignore: [main]` to the CI workflow push trigger

## Verification
- The workflow syntax is valid YAML and follows the GitHub Actions schema for `branches-ignore`