### PR TITLE
fix: Use separate AWS configs for legacy and prod DynamoDB regions

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,13 +39,18 @@ func main() {
 
 	cp := credentials.NewStaticCredentialsProvider(cfg.AwsAccessKey, cfg.AwsSecretKey, "")
 
-	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(cp), config.WithRegion("eu-north-1"))
+	awsCfgLegacy, err := config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(cp), config.WithRegion("eu-north-1"))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	identityRepository := identity.NewIdentityRepository(awsCfg)
-	clientRepository := oauth2.NewClientRepository(awsCfg)
+	awsCfgProd, err := config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(cp), config.WithRegion("eu-central-1"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	identityRepository := identity.NewIdentityRepository(awsCfgLegacy)
+	clientRepository := oauth2.NewClientRepository(awsCfgProd)
 
 	keyRepo := keys.NewInMemoryRepository()
 	keyService := keys.NewService(keyRepo)
@@ -68,7 +73,7 @@ func main() {
 	}
 
 	sessionService := authentication.SessionService{
-		SessionStore:  authentication.NewSessionRepository(awsCfg),
+		SessionStore:  authentication.NewSessionRepository(awsCfgLegacy),
 		IdentityStore: identityRepository,
 	}
 


### PR DESCRIPTION
Fixes AccessDeniedException when querying DynamoDB tables due to region mismatch between legacy (eu-north-1) and prod (eu-central-1) tables.

## Changes
- Split single AWS config into two:  (eu-north-1) and  (eu-central-1)
- Wired identity and session repositories to legacy config
- Wired client repository to prod config

## Verification
- Built the application successfully ()
- All tests pass (?   	barricade/cmd	[no test files]
ok  	barricade/internal/authentication	(cached)
ok  	barricade/internal/identity	(cached)
?   	barricade/internal/infrastructure	[no test files]
?   	barricade/internal/infrastructure/ihttp	[no test files]
?   	barricade/internal/itest	[no test files]
ok  	barricade/internal/keys	(cached)
ok  	barricade/internal/oauth2	(cached)
ok  	barricade/internal/oidc	(cached))