### PR TITLE
fix: return empty list instead of null when no clients exist

### DIFF
--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -79,7 +79,7 @@ func (h *ClientHttpHandler) List(w http.ResponseWriter, r *http.Request) error {
 		return mapClientError(r.Context(), err)
 	}
 
-	var response []listClientResponse
+	response := make([]listClientResponse, 0)
 	for _, c := range clients {
 		if c.OwnerId != ownerId {
 			continue

--- a/internal/oauth2/client_handler_test.go
+++ b/internal/oauth2/client_handler_test.go
@@ -1,0 +1,25 @@
+package oauth2
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientListEmptyReturnsEmptyList(t *testing.T) {
+	module := setupClientModule(t)
+
+	handler := ClientHttpHandler{ClientService: module.service}
+
+	ctx := context.WithValue(context.Background(), xhttp.UserId, TEST_CLIENT_OWNER_ID)
+	req := httptest.NewRequest("GET", "/v1/oauth2/clients", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	err := handler.List(rec, req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}


### PR DESCRIPTION
Changed the List clients handler to initialize the response slice as empty instead of nil, so the JSON response is `[]` rather than `null` when there are no clients.

## Changes
- Initialize `response` with `make([]listClientResponse, 0)` in `client_handler.go`
- Added handler-level test `TestClientListEmptyReturnsEmptyList` to verify the empty-list behavior

## Verification
- Ran the full `oauth2` package test suite with testcontainers DynamoDB and all tests pass