### PR TITLE
feat: migrate DynamoDB from legacy stage tables to prod schema

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -40,19 +40,14 @@ func main() {
 
 	cp := credentials.NewStaticCredentialsProvider(cfg.AwsAccessKey, cfg.AwsSecretKey, "")
 
-	awsCfgLegacy, err := config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(cp), config.WithRegion("eu-north-1"))
+	awsCfg, err := config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(cp), config.WithRegion("eu-central-1"))
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	awsCfgProd, err := config.LoadDefaultConfig(context.TODO(), config.WithCredentialsProvider(cp), config.WithRegion("eu-central-1"))
-	if err != nil {
-		log.Fatal(err)
-	}
-
-	identityRepository := identity.NewIdentityRepository(awsCfgLegacy)
-	clientRepository := oauth2.NewClientRepository(awsCfgProd)
-	authCodeRepository := oauth2.NewAuthorizationCodeRepository(awsCfgLegacy)
+	identityRepository := identity.NewIdentityRepository(awsCfg)
+	clientRepository := oauth2.NewClientRepository(awsCfg)
+	authCodeRepository := oauth2.NewAuthorizationCodeRepository(awsCfg)
 
 	keyRepo := keys.NewInMemoryRepository()
 	keyService := keys.NewService(keyRepo)
@@ -75,7 +70,7 @@ func main() {
 	}
 
 	sessionService := authentication.SessionService{
-		SessionStore:  authentication.NewSessionRepository(awsCfgLegacy),
+		SessionStore:  authentication.NewSessionRepository(awsCfg),
 		IdentityStore: identityRepository,
 	}
 

--- a/internal/authentication/session_repository.go
+++ b/internal/authentication/session_repository.go
@@ -15,34 +15,36 @@ import (
 )
 
 type dbSessionAdapter struct {
-	Id           string `dynamodbav:"id"`
-	Owner        string `dynamodbav:"secondary-lookup"`
-	ResourceType string `dynamodbav:"resource-type"`
-	CreatedAt    int64  `dynamodbav:"createdAt"`
-	ExpireAt     int64  `dynamodbav:"expireAt"`
+	Id                string `dynamodbav:"id"`
+	Type              string `dynamodbav:"type"`
+	Owner             string `dynamodbav:"secondary-lookup"`
+	SecondaryLookupSk string `dynamodbav:"secondary-lookup-sk"`
+	CreatedAt         int64  `dynamodbav:"createdAt"`
+	ExpireAt          int64  `dynamodbav:"expireAt"`
 }
 
 type DynamoDBSessionRepository struct {
-	Client    *dynamodb.Client
-	Table     *string
-	NameIndex *string
+	Client               *dynamodb.Client
+	Table                *string
+	SecondaryLookupIndex *string
 }
 
 func NewSessionRepository(cfg aws.Config) *DynamoDBSessionRepository {
 	return &DynamoDBSessionRepository{
-		Client:    dynamodb.NewFromConfig(cfg),
-		Table:     aws.String(os.Getenv("SESSION_TABLE")),
-		NameIndex: aws.String(os.Getenv("SESSION_TABLE_NAME_INDEX")),
+		Client:               dynamodb.NewFromConfig(cfg),
+		Table:                aws.String(os.Getenv("SESSION_TABLE")),
+		SecondaryLookupIndex: aws.String(os.Getenv("SESSION_TABLE_NAME_INDEX")),
 	}
 }
 
 func (r *DynamoDBSessionRepository) Save(ctx context.Context, session *Session) error {
 	dbSession := &dbSessionAdapter{
-		Id:           string(session.Id),
-		Owner:        string(session.Owner),
-		ResourceType: "session-v1",
-		CreatedAt:    session.CreatedAt,
-		ExpireAt:     session.ExpireAt,
+		Id:                string(session.Id),
+		Type:              "session",
+		Owner:             string(session.Owner),
+		SecondaryLookupSk: "session",
+		CreatedAt:         session.CreatedAt,
+		ExpireAt:          session.ExpireAt,
 	}
 
 	item, err := attributevalue.MarshalMap(dbSession)
@@ -60,9 +62,10 @@ func (r *DynamoDBSessionRepository) Save(ctx context.Context, session *Session) 
 
 func (r *DynamoDBSessionRepository) FindById(ctx context.Context, id SessionId) (*Session, error) {
 	key, _ := attributevalue.Marshal(id)
+	dbType, _ := attributevalue.Marshal("session")
 
 	output, err := r.Client.GetItem(ctx, &dynamodb.GetItemInput{
-		Key:            map[string]types.AttributeValue{"id": key},
+		Key:            map[string]types.AttributeValue{"id": key, "type": dbType},
 		TableName:      r.Table,
 		ConsistentRead: aws.Bool(false),
 	})
@@ -91,7 +94,8 @@ func (r *DynamoDBSessionRepository) FindById(ctx context.Context, id SessionId) 
 }
 
 func (r *DynamoDBSessionRepository) FindByIdentity(ctx context.Context, ownerId identity.Id) (*Session, error) {
-	keyEx := expression.Key("secondary-lookup").Equal(expression.Value(ownerId))
+	keyEx := expression.Key("secondary-lookup").Equal(expression.Value(ownerId)).
+		And(expression.Key("secondary-lookup-sk").Equal(expression.Value("session")))
 	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("failed to build expression: %v", err))
@@ -100,7 +104,7 @@ func (r *DynamoDBSessionRepository) FindByIdentity(ctx context.Context, ownerId 
 
 	output, err := r.Client.Query(ctx, &dynamodb.QueryInput{
 		TableName:                 r.Table,
-		IndexName:                 r.NameIndex,
+		IndexName:                 r.SecondaryLookupIndex,
 		KeyConditionExpression:    expr.KeyCondition(),
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),

--- a/internal/authentication/session_repository.go
+++ b/internal/authentication/session_repository.go
@@ -32,8 +32,8 @@ type DynamoDBSessionRepository struct {
 func NewSessionRepository(cfg aws.Config) *DynamoDBSessionRepository {
 	return &DynamoDBSessionRepository{
 		Client:               dynamodb.NewFromConfig(cfg),
-		Table:                aws.String(os.Getenv("SESSION_TABLE")),
-		SecondaryLookupIndex: aws.String(os.Getenv("SESSION_TABLE_NAME_INDEX")),
+		Table:                aws.String(os.Getenv("OPERATIONAL_TABLE")),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 }
 

--- a/internal/authentication/session_test.go
+++ b/internal/authentication/session_test.go
@@ -34,6 +34,10 @@ func setupSessionModule(t *testing.T) *sessionModule {
 				AttributeName: aws.String("id"),
 				KeyType:       types.KeyTypeHash,
 			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
 		},
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
@@ -41,11 +45,15 @@ func setupSessionModule(t *testing.T) *sessionModule {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
 				AttributeName: aws.String("secondary-lookup"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("resource-type"),
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
@@ -58,7 +66,7 @@ func setupSessionModule(t *testing.T) *sessionModule {
 						KeyType:       types.KeyTypeHash,
 					},
 					{
-						AttributeName: aws.String("resource-type"),
+						AttributeName: aws.String("secondary-lookup-sk"),
 						KeyType:       types.KeyTypeRange,
 					},
 				},
@@ -77,6 +85,10 @@ func setupSessionModule(t *testing.T) *sessionModule {
 				AttributeName: aws.String("id"),
 				KeyType:       types.KeyTypeHash,
 			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
 		},
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
@@ -84,22 +96,33 @@ func setupSessionModule(t *testing.T) *sessionModule {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("name"),
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("secondary-lookup"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
 		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
 			{
-				IndexName: aws.String("name-index"),
+				IndexName: aws.String("secondary-lookup-index"),
 				KeySchema: []types.KeySchemaElement{
 					{
-						AttributeName: aws.String("name"),
+						AttributeName: aws.String("secondary-lookup"),
 						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("secondary-lookup-sk"),
+						KeyType:       types.KeyTypeRange,
 					},
 				},
 				Projection: &types.Projection{
-					NonKeyAttributes: []string{"id", "secret"},
-					ProjectionType:   types.ProjectionTypeInclude,
+					ProjectionType: types.ProjectionTypeAll,
 				},
 			},
 		},
@@ -109,15 +132,15 @@ func setupSessionModule(t *testing.T) *sessionModule {
 	client := itest.SetupDynamo(t, sessionTable, identityTable)
 
 	identityStore := &identity.DynamoDBIdentityRepository{
-		Client:    client,
-		Table:     aws.String("test_identity_table"),
-		NameIndex: aws.String("name-index"),
+		Client:               client,
+		Table:                aws.String("test_identity_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	sessionStore := &DynamoDBSessionRepository{
-		Client:    client,
-		Table:     aws.String("test_session_table"),
-		NameIndex: aws.String("secondary-lookup-index"),
+		Client:               client,
+		Table:                aws.String("test_session_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	sessionService := SessionService{

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -66,11 +66,45 @@ func setupModule(t *testing.T) *identityModule {
 					AttributeName: aws.String("id"),
 					KeyType:       types.KeyTypeHash,
 				},
+				{
+					AttributeName: aws.String("type"),
+					KeyType:       types.KeyTypeRange,
+				},
 			},
 			AttributeDefinitions: []types.AttributeDefinition{
 				{
 					AttributeName: aws.String("id"),
 					AttributeType: types.ScalarAttributeTypeS,
+				},
+				{
+					AttributeName: aws.String("type"),
+					AttributeType: types.ScalarAttributeTypeS,
+				},
+				{
+					AttributeName: aws.String("secondary-lookup"),
+					AttributeType: types.ScalarAttributeTypeS,
+				},
+				{
+					AttributeName: aws.String("secondary-lookup-sk"),
+					AttributeType: types.ScalarAttributeTypeS,
+				},
+			},
+			GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
+				{
+					IndexName: aws.String("secondary-lookup-index"),
+					KeySchema: []types.KeySchemaElement{
+						{
+							AttributeName: aws.String("secondary-lookup"),
+							KeyType:       types.KeyTypeHash,
+						},
+						{
+							AttributeName: aws.String("secondary-lookup-sk"),
+							KeyType:       types.KeyTypeRange,
+						},
+					},
+					Projection: &types.Projection{
+						ProjectionType: types.ProjectionTypeAll,
+					},
 				},
 			},
 			BillingMode: types.BillingModePayPerRequest,
@@ -79,8 +113,9 @@ func setupModule(t *testing.T) *identityModule {
 	}, 30*time.Second, 1*time.Second, "Failed to create table after retries")
 
 	ddbRepository := DynamoDBIdentityRepository{
-		Client: client,
-		Table:  aws.String("test_identity_table"),
+		Client:               client,
+		Table:                aws.String("test_identity_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	return &identityModule{

--- a/internal/identity/repository.go
+++ b/internal/identity/repository.go
@@ -52,7 +52,7 @@ type DynamoDBIdentityRepository struct {
 func NewIdentityRepository(cfg aws.Config) *DynamoDBIdentityRepository {
 	return &DynamoDBIdentityRepository{
 		Client:               dynamodb.NewFromConfig(cfg),
-		Table:                aws.String(os.Getenv("IDENTITY_TABLE_NAME")),
+		Table:                aws.String(os.Getenv("ENTITIES_TABLE")),
 		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 }

--- a/internal/identity/repository.go
+++ b/internal/identity/repository.go
@@ -14,39 +14,46 @@ import (
 )
 
 type identityDDB struct {
-	Id         string `dynamodbav:"id"`
-	Name       string `dynamodbav:"name"`
-	SecretHash []byte `dynamodbav:"secret"`
-	CreatedAt  int64  `dynamodbav:"createdAt"`
-	UpdatedAt  int64  `dynamodbav:"updatedAt"`
+	Id              string `dynamodbav:"id"`
+	Type            string `dynamodbav:"type"`
+	SecondaryLookup string `dynamodbav:"secondary-lookup"`
+	SecondaryLookupSk string `dynamodbav:"secondary-lookup-sk"`
+	Name            string `dynamodbav:"name"`
+	SecretHash      []byte `dynamodbav:"secret"`
+	CreatedAt       int64  `dynamodbav:"createdAt"`
+	UpdatedAt       int64  `dynamodbav:"updatedAt"`
 }
 
 func convertToDB(identity *Identity) *identityDDB {
 	return &identityDDB{
-		Id:         string(identity.Id),
-		Name:       identity.Name,
-		SecretHash: identity.SecretHash,
-		CreatedAt:  identity.CreatedAt,
-		UpdatedAt:  identity.UpdatedAt,
+		Id:                string(identity.Id),
+		Type:              "identity",
+		SecondaryLookup:   identity.Name,
+		SecondaryLookupSk: "identity",
+		Name:              identity.Name,
+		SecretHash:        identity.SecretHash,
+		CreatedAt:         identity.CreatedAt,
+		UpdatedAt:         identity.UpdatedAt,
 	}
 }
 
 func key(id Id) map[string]types.AttributeValue {
 	dbId, _ := attributevalue.Marshal(id)
-	return map[string]types.AttributeValue{"id": dbId}
+	dbType, _ := attributevalue.Marshal("identity")
+	return map[string]types.AttributeValue{"id": dbId, "type": dbType}
 }
 
 type DynamoDBIdentityRepository struct {
-	Client    *dynamodb.Client
-	Table     *string
-	NameIndex *string
+	Client                 *dynamodb.Client
+	Table                  *string
+	SecondaryLookupIndex   *string
 }
 
 func NewIdentityRepository(cfg aws.Config) *DynamoDBIdentityRepository {
 	return &DynamoDBIdentityRepository{
-		Client:    dynamodb.NewFromConfig(cfg),
-		Table:     aws.String(os.Getenv("IDENTITY_TABLE_NAME")),
-		NameIndex: aws.String("name-index"),
+		Client:               dynamodb.NewFromConfig(cfg),
+		Table:                aws.String(os.Getenv("IDENTITY_TABLE_NAME")),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 }
 
@@ -102,7 +109,8 @@ func (r *DynamoDBIdentityRepository) FindById(ctx context.Context, id Id) (*Iden
 }
 
 func (r *DynamoDBIdentityRepository) FindByName(ctx context.Context, name string) (*Identity, error) {
-	keyEx := expression.Key("name").Equal(expression.Value(name))
+	keyEx := expression.Key("secondary-lookup").Equal(expression.Value(name)).
+		And(expression.Key("secondary-lookup-sk").Equal(expression.Value("identity")))
 	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("failed to build expression: %v", err))
@@ -111,7 +119,7 @@ func (r *DynamoDBIdentityRepository) FindByName(ctx context.Context, name string
 
 	output, err := r.Client.Query(ctx, &dynamodb.QueryInput{
 		TableName:                 r.Table,
-		IndexName:                 r.NameIndex,
+		IndexName:                 r.SecondaryLookupIndex,
 		KeyConditionExpression:    expr.KeyCondition(),
 		ExpressionAttributeNames:  expr.Names(),
 		ExpressionAttributeValues: expr.Values(),

--- a/internal/oauth2/authorization_code_repository.go
+++ b/internal/oauth2/authorization_code_repository.go
@@ -8,21 +8,20 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
-	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/expression"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
 type authCodeDDB struct {
-	Id              string `dynamodbav:"id"`
-	Type            string `dynamodbav:"type"`
-	SecondaryLookup string `dynamodbav:"secondary-lookup"`
-	ResourceType    string `dynamodbav:"resource-type"`
-	ClientId        string `dynamodbav:"clientId"`
-	RedirectURI     string `dynamodbav:"redirectURI"`
-	Scope           string `dynamodbav:"scope"`
-	CreatedAt       int64  `dynamodbav:"createdAt"`
-	ExpireAt        int64  `dynamodbav:"expireAt"`
+	Id                string `dynamodbav:"id"`
+	Type              string `dynamodbav:"type"`
+	SecondaryLookup   string `dynamodbav:"secondary-lookup"`
+	SecondaryLookupSk string `dynamodbav:"secondary-lookup-sk"`
+	ClientId          string `dynamodbav:"clientId"`
+	RedirectURI       string `dynamodbav:"redirectURI"`
+	Scope             string `dynamodbav:"scope"`
+	CreatedAt         int64  `dynamodbav:"createdAt"`
+	ExpireAt          int64  `dynamodbav:"expireAt"`
 }
 
 type AuthorizationCodeRepository interface {
@@ -32,30 +31,30 @@ type AuthorizationCodeRepository interface {
 }
 
 type DynamoDBAuthorizationCodeRepository struct {
-	Client    *dynamodb.Client
-	Table     *string
-	NameIndex *string
+	Client               *dynamodb.Client
+	Table                *string
+	SecondaryLookupIndex *string
 }
 
 func NewAuthorizationCodeRepository(cfg aws.Config) *DynamoDBAuthorizationCodeRepository {
 	return &DynamoDBAuthorizationCodeRepository{
-		Client:    dynamodb.NewFromConfig(cfg),
-		Table:     aws.String(os.Getenv("SESSION_TABLE")),
-		NameIndex: aws.String(os.Getenv("SESSION_TABLE_NAME_INDEX")),
+		Client:               dynamodb.NewFromConfig(cfg),
+		Table:                aws.String(os.Getenv("SESSION_TABLE")),
+		SecondaryLookupIndex: aws.String(os.Getenv("SESSION_TABLE_NAME_INDEX")),
 	}
 }
 
 func (r *DynamoDBAuthorizationCodeRepository) Save(ctx context.Context, code *AuthorizationCode) error {
 	dbCode := &authCodeDDB{
-		Id:              code.Code,
-		Type:            "authorization-code",
-		SecondaryLookup: code.IdentityId,
-		ResourceType:    "authorization-code",
-		ClientId:        code.ClientId,
-		RedirectURI:     code.RedirectURI,
-		Scope:           code.Scope,
-		CreatedAt:       code.CreatedAt,
-		ExpireAt:        code.ExpireAt,
+		Id:                code.Code,
+		Type:              "authorization-code",
+		SecondaryLookup:   code.IdentityId,
+		SecondaryLookupSk: "authorization-code",
+		ClientId:          code.ClientId,
+		RedirectURI:       code.RedirectURI,
+		Scope:             code.Scope,
+		CreatedAt:         code.CreatedAt,
+		ExpireAt:          code.ExpireAt,
 	}
 
 	item, err := attributevalue.MarshalMap(dbCode)
@@ -72,30 +71,24 @@ func (r *DynamoDBAuthorizationCodeRepository) Save(ctx context.Context, code *Au
 }
 
 func (r *DynamoDBAuthorizationCodeRepository) FindByCode(ctx context.Context, code string) (*AuthorizationCode, error) {
-	keyEx := expression.Key("id").Equal(expression.Value(code))
-	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
-	if err != nil {
-		slog.ErrorContext(ctx, fmt.Sprintf("failed to build expression: %v", err))
-		return nil, err
-	}
+	dbCodeId, _ := attributevalue.Marshal(code)
+	dbType, _ := attributevalue.Marshal("authorization-code")
 
-	output, err := r.Client.Query(ctx, &dynamodb.QueryInput{
-		TableName:                 r.Table,
-		KeyConditionExpression:    expr.KeyCondition(),
-		ExpressionAttributeNames:  expr.Names(),
-		ExpressionAttributeValues: expr.Values(),
-		Limit:                     aws.Int32(1),
+	output, err := r.Client.GetItem(ctx, &dynamodb.GetItemInput{
+		TableName:      r.Table,
+		Key:            map[string]types.AttributeValue{"id": dbCodeId, "type": dbType},
+		ConsistentRead: aws.Bool(false),
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	if len(output.Items) == 0 {
+	if len(output.Item) == 0 {
 		return nil, ErrInvalidCode
 	}
 
 	var dbCode authCodeDDB
-	err = attributevalue.UnmarshalMap(output.Items[0], &dbCode)
+	err = attributevalue.UnmarshalMap(output.Item, &dbCode)
 	if err != nil {
 		slog.ErrorContext(ctx, fmt.Sprintf("failed to unmarshal authorization code: %v", err))
 		return nil, err
@@ -113,45 +106,15 @@ func (r *DynamoDBAuthorizationCodeRepository) FindByCode(ctx context.Context, co
 }
 
 func (r *DynamoDBAuthorizationCodeRepository) Delete(ctx context.Context, code string) error {
-	keyEx := expression.Key("id").Equal(expression.Value(code))
-	expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
-	if err != nil {
-		slog.ErrorContext(ctx, fmt.Sprintf("failed to build expression: %v", err))
-		return err
-	}
+	dbCodeId, _ := attributevalue.Marshal(code)
+	dbType, _ := attributevalue.Marshal("authorization-code")
 
-	output, err := r.Client.Query(ctx, &dynamodb.QueryInput{
-		TableName:                 r.Table,
-		KeyConditionExpression:    expr.KeyCondition(),
-		ExpressionAttributeNames:  expr.Names(),
-		ExpressionAttributeValues: expr.Values(),
-		Limit:                     aws.Int32(1),
-	})
-	if err != nil {
-		return err
-	}
-
-	if len(output.Items) == 0 {
-		return nil
-	}
-
-	var dbCode authCodeDDB
-	err = attributevalue.UnmarshalMap(output.Items[0], &dbCode)
-	if err != nil {
-		slog.ErrorContext(ctx, fmt.Sprintf("failed to unmarshal authorization code: %v", err))
-		return err
-	}
-
-	key := map[string]types.AttributeValue{
-		"id": &types.AttributeValueMemberS{Value: dbCode.Id},
-	}
-	if dbCode.Type != "" {
-		key["type"] = &types.AttributeValueMemberS{Value: dbCode.Type}
-	}
-
-	_, err = r.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+	_, err := r.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
 		TableName: r.Table,
-		Key:       key,
+		Key: map[string]types.AttributeValue{
+			"id":   dbCodeId,
+			"type": dbType,
+		},
 	})
 
 	return err

--- a/internal/oauth2/authorization_code_repository.go
+++ b/internal/oauth2/authorization_code_repository.go
@@ -39,8 +39,8 @@ type DynamoDBAuthorizationCodeRepository struct {
 func NewAuthorizationCodeRepository(cfg aws.Config) *DynamoDBAuthorizationCodeRepository {
 	return &DynamoDBAuthorizationCodeRepository{
 		Client:               dynamodb.NewFromConfig(cfg),
-		Table:                aws.String(os.Getenv("SESSION_TABLE")),
-		SecondaryLookupIndex: aws.String(os.Getenv("SESSION_TABLE_NAME_INDEX")),
+		Table:                aws.String(os.Getenv("OPERATIONAL_TABLE")),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 }
 

--- a/internal/oauth2/authorize_service_test.go
+++ b/internal/oauth2/authorize_service_test.go
@@ -43,6 +43,10 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 				AttributeName: aws.String("id"),
 				KeyType:       types.KeyTypeHash,
 			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
 		},
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
@@ -50,11 +54,15 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
 				AttributeName: aws.String("secondary-lookup"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("resource-type"),
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
@@ -67,7 +75,7 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 						KeyType:       types.KeyTypeHash,
 					},
 					{
-						AttributeName: aws.String("resource-type"),
+						AttributeName: aws.String("secondary-lookup-sk"),
 						KeyType:       types.KeyTypeRange,
 					},
 				},
@@ -86,6 +94,10 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 				AttributeName: aws.String("id"),
 				KeyType:       types.KeyTypeHash,
 			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
 		},
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
@@ -93,22 +105,33 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("name"),
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("secondary-lookup"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
 		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
 			{
-				IndexName: aws.String("name-index"),
+				IndexName: aws.String("secondary-lookup-index"),
 				KeySchema: []types.KeySchemaElement{
 					{
-						AttributeName: aws.String("name"),
+						AttributeName: aws.String("secondary-lookup"),
 						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("secondary-lookup-sk"),
+						KeyType:       types.KeyTypeRange,
 					},
 				},
 				Projection: &types.Projection{
-					NonKeyAttributes: []string{"id", "secret"},
-					ProjectionType:   types.ProjectionTypeInclude,
+					ProjectionType: types.ProjectionTypeAll,
 				},
 			},
 		},
@@ -166,7 +189,7 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("resource-type"),
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
@@ -179,7 +202,7 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 						KeyType:       types.KeyTypeHash,
 					},
 					{
-						AttributeName: aws.String("resource-type"),
+						AttributeName: aws.String("secondary-lookup-sk"),
 						KeyType:       types.KeyTypeRange,
 					},
 				},
@@ -194,15 +217,15 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 	client := itest.SetupDynamo(t, sessionTable, identityTable, entitiesTable, operationalTable)
 
 	identityStore := &identity.DynamoDBIdentityRepository{
-		Client:    client,
-		Table:     aws.String("test_identity_table"),
-		NameIndex: aws.String("name-index"),
+		Client:               client,
+		Table:                aws.String("test_identity_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	sessionStore := &authentication.DynamoDBSessionRepository{
-		Client:    client,
-		Table:     aws.String("test_session_table"),
-		NameIndex: aws.String("secondary-lookup-index"),
+		Client:               client,
+		Table:                aws.String("test_session_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	sessionService := authentication.SessionService{
@@ -223,9 +246,9 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 	}
 
 	authCodeRepository := &DynamoDBAuthorizationCodeRepository{
-		Client:    client,
-		Table:     aws.String("test_operational_table"),
-		NameIndex: aws.String("secondary-lookup-index"),
+		Client:               client,
+		Table:                aws.String("test_operational_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	clientService := ClientService{Repo: clientRepository}

--- a/internal/oauth2/client_repository.go
+++ b/internal/oauth2/client_repository.go
@@ -79,7 +79,7 @@ type DynamoDBClientRepository struct {
 func NewClientRepository(cfg aws.Config) *DynamoDBClientRepository {
 	return &DynamoDBClientRepository{
 		Client:           dynamodb.NewFromConfig(cfg),
-		Table:            aws.String(os.Getenv("CLIENT_TABLE_NAME")),
+		Table:            aws.String(os.Getenv("ENTITIES_TABLE")),
 		ShardedTypeIndex: aws.String("sharded-type-index"),
 	}
 }

--- a/internal/oauth2/token_service_test.go
+++ b/internal/oauth2/token_service_test.go
@@ -24,6 +24,10 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 				AttributeName: aws.String("id"),
 				KeyType:       types.KeyTypeHash,
 			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
 		},
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
@@ -31,11 +35,15 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
 				AttributeName: aws.String("secondary-lookup"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("resource-type"),
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
@@ -48,7 +56,7 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 						KeyType:       types.KeyTypeHash,
 					},
 					{
-						AttributeName: aws.String("resource-type"),
+						AttributeName: aws.String("secondary-lookup-sk"),
 						KeyType:       types.KeyTypeRange,
 					},
 				},
@@ -67,6 +75,10 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 				AttributeName: aws.String("id"),
 				KeyType:       types.KeyTypeHash,
 			},
+			{
+				AttributeName: aws.String("type"),
+				KeyType:       types.KeyTypeRange,
+			},
 		},
 		AttributeDefinitions: []types.AttributeDefinition{
 			{
@@ -74,22 +86,33 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("name"),
+				AttributeName: aws.String("type"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("secondary-lookup"),
+				AttributeType: types.ScalarAttributeTypeS,
+			},
+			{
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
 		GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
 			{
-				IndexName: aws.String("name-index"),
+				IndexName: aws.String("secondary-lookup-index"),
 				KeySchema: []types.KeySchemaElement{
 					{
-						AttributeName: aws.String("name"),
+						AttributeName: aws.String("secondary-lookup"),
 						KeyType:       types.KeyTypeHash,
+					},
+					{
+						AttributeName: aws.String("secondary-lookup-sk"),
+						KeyType:       types.KeyTypeRange,
 					},
 				},
 				Projection: &types.Projection{
-					NonKeyAttributes: []string{"id", "secret"},
-					ProjectionType:   types.ProjectionTypeInclude,
+					ProjectionType: types.ProjectionTypeAll,
 				},
 			},
 		},
@@ -147,7 +170,7 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 			{
-				AttributeName: aws.String("resource-type"),
+				AttributeName: aws.String("secondary-lookup-sk"),
 				AttributeType: types.ScalarAttributeTypeS,
 			},
 		},
@@ -160,7 +183,7 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 						KeyType:       types.KeyTypeHash,
 					},
 					{
-						AttributeName: aws.String("resource-type"),
+						AttributeName: aws.String("secondary-lookup-sk"),
 						KeyType:       types.KeyTypeRange,
 					},
 				},
@@ -175,15 +198,15 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 	client := itest.SetupDynamo(t, sessionTable, identityTable, entitiesTable, operationalTable)
 
 	identityStore := &identity.DynamoDBIdentityRepository{
-		Client:    client,
-		Table:     aws.String("test_identity_table"),
-		NameIndex: aws.String("name-index"),
+		Client:               client,
+		Table:                aws.String("test_identity_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	sessionStore := &authentication.DynamoDBSessionRepository{
-		Client:    client,
-		Table:     aws.String("test_session_table"),
-		NameIndex: aws.String("secondary-lookup-index"),
+		Client:               client,
+		Table:                aws.String("test_session_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	clientRepository := &DynamoDBClientRepository{
@@ -192,9 +215,9 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 	}
 
 	authCodeRepository := &DynamoDBAuthorizationCodeRepository{
-		Client:    client,
-		Table:     aws.String("test_operational_table"),
-		NameIndex: aws.String("secondary-lookup-index"),
+		Client:               client,
+		Table:                aws.String("test_operational_table"),
+		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
 	}
 
 	keyRepo := keys.NewInMemoryRepository()


### PR DESCRIPTION
Migrate all repositories from legacy stage DynamoDB tables (eu-north-1) to prod tables (eu-central-1) defined in IaC, and simplify env var management.

## Changes
- **cmd/main.go**: Remove legacy AWS config, consolidate to single prod region (eu-central-1)
- **identity repository**: Switch from `name-index` to `secondary-lookup-index` GSI, use composite key (`id` + `type`)
- **session repository**: Rename `resource-type` to `secondary-lookup-sk`, use composite key, query GSI with both keys
- **authorization code repository**: Add `secondary-lookup-sk`, use `GetItem` with composite key instead of `Query`, simplify `Delete`
- **env vars**: Consolidated from 4 vars (`IDENTITY_TABLE_NAME`, `SESSION_TABLE`, `CLIENT_TABLE_NAME`, `SESSION_TABLE_NAME_INDEX`) to 2 (`ENTITIES_TABLE`, `OPERATIONAL_TABLE`); GSI names are now hardcoded
- **Test files**: Update test table schemas to match prod IaC (composite keys, correct GSIs)

## Verification
- All 6 test packages pass with `go test -count=1 ./...` (identity, authentication, oauth2, keys, oidc)
- `make build` compiles successfully