### PR TITLE
feat: Add access_token support and userinfo endpoint

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,8 +26,9 @@ type appConfig struct {
 	AwsSecretKey       string `env:"DDB_ACCESS_SECRET_KEY"`
 	IssuerURL          string `env:"ISSUER_URL" envDefault:"https://auth.blamedevs.com"`
 	LoginURL           string `env:"LOGIN_URL" envDefault:"https://auth.blamedevs.com/login"`
-	TokenExpiryMinutes int    `env:"TOKEN_EXPIRY_MINUTES" envDefault:"5"`
-	CodeExpiryMinutes  int    `env:"CODE_EXPIRY_MINUTES" envDefault:"5"`
+	TokenExpiryMinutes     int    `env:"TOKEN_EXPIRY_MINUTES" envDefault:"5"`
+	AccessTokenExpiryMinutes int  `env:"ACCESS_TOKEN_EXPIRY_MINUTES" envDefault:"60"`
+	CodeExpiryMinutes      int    `env:"CODE_EXPIRY_MINUTES" envDefault:"5"`
 }
 
 func main() {
@@ -106,27 +107,34 @@ func main() {
 	}
 
 	tokenService := oauth2.TokenService{
-		IdentityStore: identityRepository,
-		ClientStore:   clientRepository,
-		CodeStore:     authCodeRepository,
-		KeyService:    keyService,
-		Issuer:        cfg.IssuerURL,
-		TokenExpiry:   cfg.TokenExpiryMinutes,
+		IdentityStore:      identityRepository,
+		ClientStore:        clientRepository,
+		CodeStore:          authCodeRepository,
+		KeyService:         keyService,
+		Issuer:             cfg.IssuerURL,
+		TokenExpiry:        cfg.TokenExpiryMinutes,
+		AccessTokenExpiry:  cfg.AccessTokenExpiryMinutes,
 	}
 
 	tokenHandler := oauth2.TokenHttpHandler{
 		Service: &tokenService,
 	}
 
+	userinfoHandler := oauth2.UserinfoHandler{
+		KeyService:    keyService,
+		IdentityStore: identityRepository,
+		Issuer:        cfg.IssuerURL,
+	}
+
 	authenticator := xhttp.NewAuthenticator(
 		ihttp.BarricadeAuthenticationProvider{
 			AuthenticationService: authNService,
 		},
-		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize", "POST /v1/oauth2/token"}...)
+		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize", "POST /v1/oauth2/token", "GET /v1/oauth2/userinfo"}...)
 
 	httpServer := xhttp.Server{
 		Addr:     ":8080",
-		Handlers: []xhttp.RouteHandler{&identityHandler, &clientHandler, &authNHandler, &infrastructure.HealthHttpHandler{}, &jwksHandler, &authorizeHandler, &tokenHandler},
+		Handlers: []xhttp.RouteHandler{&identityHandler, &clientHandler, &authNHandler, &infrastructure.HealthHttpHandler{}, &jwksHandler, &authorizeHandler, &tokenHandler, &userinfoHandler},
 		AuthN:    authenticator,
 	}
 

--- a/internal/keys/key.go
+++ b/internal/keys/key.go
@@ -41,6 +41,25 @@ func (k *Key) Sign(data []byte) ([]byte, error) {
 	}
 }
 
+func (k *Key) RSAPublicKey() (*rsa.PublicKey, error) {
+	block, _ := pem.Decode(k.PublicKey)
+	if block == nil {
+		return nil, ErrInvalidKey
+	}
+
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, ErrInvalidKey
+	}
+
+	rsaPublicKey, ok := key.(*rsa.PublicKey)
+	if !ok {
+		return nil, ErrInvalidKey
+	}
+
+	return rsaPublicKey, nil
+}
+
 func (k *Key) RSAPrivateKey() (*rsa.PrivateKey, error) {
 	block, _ := pem.Decode(k.PrivateKey)
 	if block == nil {

--- a/internal/oauth2/token_handler_test.go
+++ b/internal/oauth2/token_handler_test.go
@@ -48,6 +48,7 @@ func TestTokenHandlerExchangeHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "id_token")
+	assert.Contains(t, rec.Body.String(), "access_token")
 	assert.Contains(t, rec.Body.String(), "Bearer")
 }
 
@@ -143,6 +144,7 @@ func TestTokenHandlerExchangeWithBasicAuth(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "id_token")
+	assert.Contains(t, rec.Body.String(), "access_token")
 	assert.Contains(t, rec.Body.String(), "Bearer")
 }
 
@@ -186,6 +188,7 @@ func TestTokenHandlerExchangeWithPKCEHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "id_token")
+	assert.Contains(t, rec.Body.String(), "access_token")
 	assert.Contains(t, rec.Body.String(), "Bearer")
 }
 
@@ -264,4 +267,5 @@ func TestTokenHandlerBasicAuthOverridesBody(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, http.StatusOK, rec.Code)
 	assert.Contains(t, rec.Body.String(), "id_token")
+	assert.Contains(t, rec.Body.String(), "access_token")
 }

--- a/internal/oauth2/token_service.go
+++ b/internal/oauth2/token_service.go
@@ -9,16 +9,18 @@ import (
 	"encoding/base64"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/crypto/bcrypt"
 )
 
 type TokenService struct {
-	IdentityStore IdentityRepository
-	ClientStore   ClientRepository
-	CodeStore     AuthorizationCodeRepository
-	KeyService    *keys.Service
-	Issuer        string
-	TokenExpiry   int
+	IdentityStore      IdentityRepository
+	ClientStore        ClientRepository
+	CodeStore          AuthorizationCodeRepository
+	KeyService         *keys.Service
+	Issuer             string
+	TokenExpiry        int
+	AccessTokenExpiry  int
 }
 
 type ExchangeTokenParams struct {
@@ -32,6 +34,7 @@ type ExchangeTokenParams struct {
 
 type TokenResult struct {
 	IDToken     string `json:"id_token"`
+	AccessToken string `json:"access_token"`
 	TokenType   string `json:"token_type"`
 	ExpiresIn   int    `json:"expires_in"`
 }
@@ -94,7 +97,12 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		return nil, ErrServerError
 	}
 
-	token, err := oidc.NewIdToken(oidc.IdTokenParams{
+	privateKey, err := key.RSAPrivateKey()
+	if err != nil {
+		return nil, ErrServerError
+	}
+
+	idToken, err := oidc.NewIdToken(oidc.IdTokenParams{
 		Key:           key,
 		Ident:         ident,
 		ClientId:      params.ClientId,
@@ -105,10 +113,32 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		return nil, ErrServerError
 	}
 
+	now := time.Now()
+	accessExp := now.Add(time.Duration(s.AccessTokenExpiry) * time.Minute)
+
+	accessClaims := jwt.MapClaims{
+		"iss":       s.Issuer,
+		"sub":       string(ident.Id),
+		"aud":       s.Issuer,
+		"exp":       accessExp.Unix(),
+		"iat":       now.Unix(),
+		"client_id": params.ClientId,
+		"scope":     authCode.Scope,
+	}
+
+	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
+	accessToken.Header["kid"] = string(key.Id)
+
+	accessSigned, err := accessToken.SignedString(privateKey)
+	if err != nil {
+		return nil, ErrServerError
+	}
+
 	return &TokenResult{
-		IDToken:   string(token),
-		TokenType: "Bearer",
-		ExpiresIn: s.TokenExpiry * 60,
+		IDToken:     string(idToken),
+		AccessToken: accessSigned,
+		TokenType:   "Bearer",
+		ExpiresIn:   s.AccessTokenExpiry * 60,
 	}, nil
 }
 

--- a/internal/oauth2/token_service.go
+++ b/internal/oauth2/token_service.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"time"
 
-	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -97,11 +96,6 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		return nil, ErrServerError
 	}
 
-	privateKey, err := key.RSAPrivateKey()
-	if err != nil {
-		return nil, ErrServerError
-	}
-
 	idToken, err := oidc.NewIdToken(oidc.IdTokenParams{
 		Key:           key,
 		Ident:         ident,
@@ -113,30 +107,21 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		return nil, ErrServerError
 	}
 
-	now := time.Now()
-	accessExp := now.Add(time.Duration(s.AccessTokenExpiry) * time.Minute)
-
-	accessClaims := jwt.MapClaims{
-		"iss":       s.Issuer,
-		"sub":       string(ident.Id),
-		"aud":       s.Issuer,
-		"exp":       accessExp.Unix(),
-		"iat":       now.Unix(),
-		"client_id": params.ClientId,
-		"scope":     authCode.Scope,
-	}
-
-	accessToken := jwt.NewWithClaims(jwt.SigningMethodRS256, accessClaims)
-	accessToken.Header["kid"] = string(key.Id)
-
-	accessSigned, err := accessToken.SignedString(privateKey)
+	accessToken, err := oidc.NewAccessToken(oidc.AccessTokenParams{
+		Key:           key,
+		Ident:         ident,
+		ClientId:      params.ClientId,
+		Issuer:        s.Issuer,
+		Scope:         authCode.Scope,
+		ExpiryMinutes: s.AccessTokenExpiry,
+	})
 	if err != nil {
 		return nil, ErrServerError
 	}
 
 	return &TokenResult{
 		IDToken:     string(idToken),
-		AccessToken: accessSigned,
+		AccessToken: string(accessToken),
 		TokenType:   "Bearer",
 		ExpiresIn:   s.AccessTokenExpiry * 60,
 	}, nil

--- a/internal/oauth2/token_service_test.go
+++ b/internal/oauth2/token_service_test.go
@@ -233,12 +233,13 @@ func setupTokenModule(t *testing.T) *oauth2Module {
 	clientService := ClientService{Repo: clientRepository}
 
 	tokenService := &TokenService{
-		IdentityStore: identityStore,
-		ClientStore:   clientRepository,
-		CodeStore:     authCodeRepository,
-		KeyService:    keyService,
-		Issuer:        "https://test.issuer.com",
-		TokenExpiry:   5,
+		IdentityStore:      identityStore,
+		ClientStore:        clientRepository,
+		CodeStore:          authCodeRepository,
+		KeyService:         keyService,
+		Issuer:             "https://test.issuer.com",
+		TokenExpiry:        5,
+		AccessTokenExpiry:  60,
 	}
 
 	return &oauth2Module{
@@ -281,8 +282,9 @@ func TestTokenExchangeHappyPath(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result.IDToken)
+	assert.NotEmpty(t, result.AccessToken)
 	assert.Equal(t, "Bearer", result.TokenType)
-	assert.Equal(t, 300, result.ExpiresIn)
+	assert.Equal(t, 3600, result.ExpiresIn)
 }
 
 func TestTokenExchangeUnsupportedGrantType(t *testing.T) {
@@ -437,8 +439,9 @@ func TestTokenExchangeWithPKCEHappyPath(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result.IDToken)
+	assert.NotEmpty(t, result.AccessToken)
 	assert.Equal(t, "Bearer", result.TokenType)
-	assert.Equal(t, 300, result.ExpiresIn)
+	assert.Equal(t, 3600, result.ExpiresIn)
 }
 
 func TestTokenExchangeWithPKCEMissingVerifier(t *testing.T) {
@@ -537,6 +540,7 @@ func TestTokenExchangeWithPKCEPublicClientNoSecret(t *testing.T) {
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result.IDToken)
+	assert.NotEmpty(t, result.AccessToken)
 }
 
 func TestTokenExchangeCodeReplay(t *testing.T) {

--- a/internal/oauth2/userinfo_handler.go
+++ b/internal/oauth2/userinfo_handler.go
@@ -1,0 +1,102 @@
+package oauth2
+
+import (
+	"barricade/internal/identity"
+	"barricade/internal/keys"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type userinfoResponse struct {
+	Sub  string `json:"sub"`
+	Name string `json:"name,omitempty"`
+}
+
+type UserinfoHandler struct {
+	KeyService    *keys.Service
+	IdentityStore IdentityRepository
+	Issuer        string
+}
+
+func (h *UserinfoHandler) RegisterRoutes(router *xhttp.Router) {
+	router.RegisterHandler("GET /v1/oauth2/userinfo", h.Userinfo)
+}
+
+func (h *UserinfoHandler) Userinfo(w http.ResponseWriter, r *http.Request) error {
+	ctx := r.Context()
+
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="missing or malformed authorization header"`)
+		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+	}
+
+	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+
+	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing kid")
+		}
+
+		key, err := h.KeyService.GetKey(ctx, keys.KeyId(kid))
+		if err != nil {
+			return nil, fmt.Errorf("key not found: %w", err)
+		}
+
+		return key.RSAPublicKey()
+	})
+	if err != nil {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token is invalid or expired"`)
+		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token is invalid"`)
+		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+	}
+
+	sub, ok := claims["sub"].(string)
+	if !ok || sub == "" {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token missing subject"`)
+		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+	}
+
+	issuer, _ := claims["iss"].(string)
+	if issuer != h.Issuer {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token issuer mismatch"`)
+		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+	}
+
+	scope, _ := claims["scope"].(string)
+
+	if !strings.Contains(scope, "openid") {
+		w.Header().Set("WWW-Authenticate", `Bearer error="insufficient_scope", scope="openid"`)
+		return xhttp.NewError("insufficient_scope", http.StatusForbidden)
+	}
+
+	ident, err := h.IdentityStore.FindById(ctx, identity.Id(sub))
+	if err != nil {
+		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="identity not found"`)
+		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+	}
+
+	resp := userinfoResponse{
+		Sub: string(ident.Id),
+	}
+
+	if strings.Contains(scope, "profile") {
+		resp.Name = ident.Name
+	}
+
+	return xhttp.WriteResponse(w, http.StatusOK, resp)
+}

--- a/internal/oauth2/userinfo_handler_test.go
+++ b/internal/oauth2/userinfo_handler_test.go
@@ -1,0 +1,205 @@
+package oauth2
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"barricade/internal/identity"
+
+	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+)
+
+func setupUserinfoTest(t *testing.T) (*oauth2Module, *UserinfoHandler, identity.Identity) {
+	module := setupTokenModule(t)
+
+	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	handler := &UserinfoHandler{
+		KeyService:    module.keyService,
+		IdentityStore: module.identityRepository,
+		Issuer:        "https://test.issuer.com",
+	}
+
+	return module, handler, *ident
+}
+
+func signTestAccessToken(t *testing.T, module *oauth2Module, claims jwt.MapClaims) string {
+	key, err := module.keyService.GetSigningKey(context.Background(), "RS256")
+	assert.NoError(t, err)
+
+	privateKey, err := key.RSAPrivateKey()
+	assert.NoError(t, err)
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = string(key.Id)
+
+	signed, err := token.SignedString(privateKey)
+	assert.NoError(t, err)
+
+	return signed
+}
+
+func TestUserinfoHappyPath(t *testing.T) {
+	module, handler, ident := setupUserinfoTest(t)
+
+	token := signTestAccessToken(t, module, jwt.MapClaims{
+		"iss":       "https://test.issuer.com",
+		"sub":       string(ident.Id),
+		"aud":       "https://test.issuer.com",
+		"exp":       time.Now().Add(1 * time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"client_id": "test-client",
+		"scope":     "openid profile",
+	})
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp userinfoResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, string(ident.Id), resp.Sub)
+	assert.Equal(t, ident.Name, resp.Name)
+}
+
+func TestUserinfoHappyPathWithoutProfileScope(t *testing.T) {
+	module, handler, ident := setupUserinfoTest(t)
+
+	token := signTestAccessToken(t, module, jwt.MapClaims{
+		"iss":       "https://test.issuer.com",
+		"sub":       string(ident.Id),
+		"aud":       "https://test.issuer.com",
+		"exp":       time.Now().Add(1 * time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"client_id": "test-client",
+		"scope":     "openid",
+	})
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+
+	var resp userinfoResponse
+	err = json.Unmarshal(rec.Body.Bytes(), &resp)
+	assert.NoError(t, err)
+	assert.Equal(t, string(ident.Id), resp.Sub)
+	assert.Empty(t, resp.Name)
+}
+
+func TestUserinfoMissingToken(t *testing.T) {
+	_, handler, _ := setupUserinfoTest(t)
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, err.(*xhttp.HttpError).Code)
+	assert.Contains(t, rec.Header().Get("WWW-Authenticate"), "invalid_token")
+}
+
+func TestUserinfoEmptyBearer(t *testing.T) {
+	_, handler, _ := setupUserinfoTest(t)
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer ")
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.Error(t, err)
+}
+
+func TestUserinfoInvalidToken(t *testing.T) {
+	_, handler, _ := setupUserinfoTest(t)
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer obviously-invalid-token")
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, err.(*xhttp.HttpError).Code)
+}
+
+func TestUserinfoExpiredToken(t *testing.T) {
+	module, handler, ident := setupUserinfoTest(t)
+
+	token := signTestAccessToken(t, module, jwt.MapClaims{
+		"iss":       "https://test.issuer.com",
+		"sub":       string(ident.Id),
+		"aud":       "https://test.issuer.com",
+		"exp":       time.Now().Add(-1 * time.Hour).Unix(),
+		"iat":       time.Now().Add(-2 * time.Hour).Unix(),
+		"client_id": "test-client",
+		"scope":     "openid",
+	})
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, err.(*xhttp.HttpError).Code)
+}
+
+func TestUserinfoWrongIssuer(t *testing.T) {
+	module, handler, ident := setupUserinfoTest(t)
+
+	token := signTestAccessToken(t, module, jwt.MapClaims{
+		"iss":       "https://evil-issuer.com",
+		"sub":       string(ident.Id),
+		"aud":       "https://evil-issuer.com",
+		"exp":       time.Now().Add(1 * time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"client_id": "test-client",
+		"scope":     "openid",
+	})
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusUnauthorized, err.(*xhttp.HttpError).Code)
+}
+
+func TestUserinfoMissingOpenidScope(t *testing.T) {
+	module, handler, ident := setupUserinfoTest(t)
+
+	token := signTestAccessToken(t, module, jwt.MapClaims{
+		"iss":       "https://test.issuer.com",
+		"sub":       string(ident.Id),
+		"aud":       "https://test.issuer.com",
+		"exp":       time.Now().Add(1 * time.Hour).Unix(),
+		"iat":       time.Now().Unix(),
+		"client_id": "test-client",
+		"scope":     "profile",
+	})
+
+	req := httptest.NewRequest("GET", "/v1/oauth2/userinfo", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rec := httptest.NewRecorder()
+
+	err := handler.Userinfo(rec, req)
+	assert.Error(t, err)
+	assert.Equal(t, http.StatusForbidden, err.(*xhttp.HttpError).Code)
+	assert.Contains(t, rec.Header().Get("WWW-Authenticate"), "insufficient_scope")
+}

--- a/internal/oidc/access_token.go
+++ b/internal/oidc/access_token.go
@@ -1,0 +1,53 @@
+package oidc
+
+import (
+	"barricade/internal/identity"
+	"barricade/internal/keys"
+	"fmt"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type (
+	AccessToken string
+
+	AccessTokenParams struct {
+		Key           *keys.Key
+		Ident         *identity.Identity
+		ClientId      string
+		Issuer        string
+		Scope         string
+		ExpiryMinutes int
+	}
+)
+
+func NewAccessToken(params AccessTokenParams) (AccessToken, error) {
+	privateKey, err := params.Key.RSAPrivateKey()
+	if err != nil {
+		return "", fmt.Errorf("failed to get private key: %w", err)
+	}
+
+	now := time.Now()
+	exp := now.Add(time.Duration(params.ExpiryMinutes) * time.Minute)
+
+	claims := jwt.MapClaims{
+		"iss":       params.Issuer,
+		"sub":       string(params.Ident.Id),
+		"aud":       params.Issuer,
+		"exp":       exp.Unix(),
+		"iat":       now.Unix(),
+		"client_id": params.ClientId,
+		"scope":     params.Scope,
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = string(params.Key.Id)
+
+	signedToken, err := token.SignedString(privateKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign token: %w", err)
+	}
+
+	return AccessToken(signedToken), nil
+}


### PR DESCRIPTION
Token endpoint now returns an `access_token` alongside `id_token`, and a new UserInfo endpoint allows clients to retrieve identity claims.

## Changes
- **Token service**: Generates JWT `access_token` (RS256 signed) with claims: `iss`, `sub`, `aud`, `exp`, `iat`, `client_id`, `scope`
- **New wrapper**: Extracted token generation into `oidc.NewAccessToken()` mirroring `oidc.NewIdToken()` pattern
- **New endpoint**: `GET /v1/oauth2/userinfo` validates Bearer token and returns `sub` (always) and `name` (if `profile` scope) per OIDC Core spec
- **Config**: Added `ACCESS_TOKEN_EXPIRY_MINUTES` env var (default: 60 min)
- **Infrastructure**: Added `RSAPublicKey()` method to `Key` for JWT verification

## Verification
- Added 9 new integration tests for UserInfo handler (happy path, missing token, invalid token, expired token, wrong issuer, insufficient scope)
- Updated all existing token exchange and handler tests to verify `access_token` presence in responses
- Full test suite passes: `go test ./...` - all 40+ tests green