### PR TITLE
refactor: extract userinfo logic into UserinfoService

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -120,10 +120,14 @@ func main() {
 		Service: &tokenService,
 	}
 
-	userinfoHandler := oauth2.UserinfoHandler{
+	userinfoService := oauth2.UserinfoService{
 		KeyService:    keyService,
 		IdentityStore: identityRepository,
 		Issuer:        cfg.IssuerURL,
+	}
+
+	userinfoHandler := oauth2.UserinfoHandler{
+		Service: &userinfoService,
 	}
 
 	authenticator := xhttp.NewAuthenticator(

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -27,4 +27,6 @@ var (
 	ErrInvalidCodeChallengeMethod      = errors.New("invalid code challenge method, only S256 is supported")
 	ErrInvalidCodeVerifier             = errors.New("invalid code verifier")
 	ErrMissingCodeVerifier             = errors.New("code verifier is required for PKCE authorization code")
+	ErrInvalidToken                    = errors.New("invalid token")
+	ErrInsufficientScope               = errors.New("insufficient scope")
 )

--- a/internal/oauth2/userinfo_handler.go
+++ b/internal/oauth2/userinfo_handler.go
@@ -1,14 +1,11 @@
 package oauth2
 
 import (
-	"barricade/internal/identity"
-	"barricade/internal/keys"
-	"fmt"
+	"errors"
 	"net/http"
 	"strings"
 
 	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
-	"github.com/golang-jwt/jwt/v5"
 )
 
 type userinfoResponse struct {
@@ -17,9 +14,7 @@ type userinfoResponse struct {
 }
 
 type UserinfoHandler struct {
-	KeyService    *keys.Service
-	IdentityStore IdentityRepository
-	Issuer        string
+	Service *UserinfoService
 }
 
 func (h *UserinfoHandler) RegisterRoutes(router *xhttp.Router) {
@@ -35,68 +30,32 @@ func (h *UserinfoHandler) Userinfo(w http.ResponseWriter, r *http.Request) error
 		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
 	}
 
-	tokenString := strings.TrimPrefix(authHeader, "Bearer ")
+	accessToken := strings.TrimPrefix(authHeader, "Bearer ")
 
-	token, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
-		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-
-		kid, ok := token.Header["kid"].(string)
-		if !ok {
-			return nil, fmt.Errorf("missing kid")
-		}
-
-		key, err := h.KeyService.GetKey(ctx, keys.KeyId(kid))
-		if err != nil {
-			return nil, fmt.Errorf("key not found: %w", err)
-		}
-
-		return key.RSAPublicKey()
-	})
+	result, err := h.Service.GetUserinfo(ctx, accessToken)
 	if err != nil {
-		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token is invalid or expired"`)
-		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
-	}
-
-	claims, ok := token.Claims.(jwt.MapClaims)
-	if !ok || !token.Valid {
-		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token is invalid"`)
-		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
-	}
-
-	sub, ok := claims["sub"].(string)
-	if !ok || sub == "" {
-		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token missing subject"`)
-		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
-	}
-
-	issuer, _ := claims["iss"].(string)
-	if issuer != h.Issuer {
-		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="access token issuer mismatch"`)
-		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
-	}
-
-	scope, _ := claims["scope"].(string)
-
-	if !strings.Contains(scope, "openid") {
-		w.Header().Set("WWW-Authenticate", `Bearer error="insufficient_scope", scope="openid"`)
-		return xhttp.NewError("insufficient_scope", http.StatusForbidden)
-	}
-
-	ident, err := h.IdentityStore.FindById(ctx, identity.Id(sub))
-	if err != nil {
-		w.Header().Set("WWW-Authenticate", `Bearer error="invalid_token", error_description="identity not found"`)
-		return xhttp.NewError("invalid_token", http.StatusUnauthorized)
+		code, status := mapUserinfoError(err)
+		if desc := errorDescription(err); desc != "" {
+			w.Header().Set("WWW-Authenticate", `Bearer error="`+code+`", error_description="`+desc+`"`)
+		} else {
+			w.Header().Set("WWW-Authenticate", userinfoWWWAuthenticate(code))
+		}
+		return xhttp.NewError(code, status)
 	}
 
 	resp := userinfoResponse{
-		Sub: string(ident.Id),
-	}
-
-	if strings.Contains(scope, "profile") {
-		resp.Name = ident.Name
+		Sub:  result.Sub,
+		Name: result.Name,
 	}
 
 	return xhttp.WriteResponse(w, http.StatusOK, resp)
+}
+
+func errorDescription(err error) string {
+	switch {
+	case errors.Is(err, ErrInsufficientScope):
+		return ""
+	default:
+		return "access token is invalid"
+	}
 }

--- a/internal/oauth2/userinfo_handler_test.go
+++ b/internal/oauth2/userinfo_handler_test.go
@@ -21,10 +21,14 @@ func setupUserinfoTest(t *testing.T) (*oauth2Module, *UserinfoHandler, identity.
 	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
 	assert.NoError(t, err)
 
-	handler := &UserinfoHandler{
+	service := &UserinfoService{
 		KeyService:    module.keyService,
 		IdentityStore: module.identityRepository,
 		Issuer:        "https://test.issuer.com",
+	}
+
+	handler := &UserinfoHandler{
+		Service: service,
 	}
 
 	return module, handler, *ident

--- a/internal/oauth2/userinfo_service.go
+++ b/internal/oauth2/userinfo_service.go
@@ -1,0 +1,104 @@
+package oauth2
+
+import (
+	"barricade/internal/identity"
+	"barricade/internal/keys"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+type UserinfoResult struct {
+	Sub  string
+	Name string
+}
+
+type UserinfoService struct {
+	KeyService    *keys.Service
+	IdentityStore IdentityRepository
+	Issuer        string
+}
+
+func (s *UserinfoService) GetUserinfo(ctx context.Context, accessToken string) (*UserinfoResult, error) {
+	token, err := jwt.Parse(accessToken, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing kid")
+		}
+
+		key, err := s.KeyService.GetKey(ctx, keys.KeyId(kid))
+		if err != nil {
+			return nil, fmt.Errorf("key not found: %w", err)
+		}
+
+		return key.RSAPublicKey()
+	})
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return nil, ErrInvalidToken
+	}
+
+	sub, ok := claims["sub"].(string)
+	if !ok || sub == "" {
+		return nil, ErrInvalidToken
+	}
+
+	issuer, _ := claims["iss"].(string)
+	if issuer != s.Issuer {
+		return nil, ErrInvalidToken
+	}
+
+	scope, _ := claims["scope"].(string)
+
+	if !strings.Contains(scope, "openid") {
+		return nil, ErrInsufficientScope
+	}
+
+	ident, err := s.IdentityStore.FindById(ctx, identity.Id(sub))
+	if err != nil {
+		return nil, ErrInvalidToken
+	}
+
+	result := &UserinfoResult{
+		Sub: string(ident.Id),
+	}
+
+	if strings.Contains(scope, "profile") {
+		result.Name = ident.Name
+	}
+
+	return result, nil
+}
+
+func mapUserinfoError(err error) (string, int) {
+	switch {
+	case errors.Is(err, ErrInvalidToken):
+		return "invalid_token", 401
+	case errors.Is(err, ErrInsufficientScope):
+		return "insufficient_scope", 403
+	default:
+		return "server_error", 500
+	}
+}
+
+func userinfoWWWAuthenticate(code string) string {
+	switch code {
+	case "invalid_token":
+		return `Bearer error="invalid_token"`
+	case "insufficient_scope":
+		return `Bearer error="insufficient_scope", scope="openid"`
+	default:
+		return ""
+	}
+}


### PR DESCRIPTION
## Summary

Extracts userinfo business logic from the handler into a dedicated `UserinfoService`, following the project's service layer pattern.

## Changes

- **New `UserinfoService`**: handles token parsing, validation (signing method, issuer, expiry, scope), and identity lookup
- **New domain errors**: `ErrInvalidToken` and `ErrInsufficientScope` for clean error handling
- **`UserinfoHandler`** is now thin: parses request, delegates to service, writes response
- **Helper functions**: `mapUserinfoError` and `userinfoWWWAuthenticate` for standardized error responses
- **Tests**: updated to use the refactored handler signature