### PR TITLE
chore: remove implicit flow support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,13 +91,9 @@ func main() {
 	}
 
 	authorizeService := oauth2.AuthorizeService{
-		IdentityStore: identityRepository,
-		ClientStore:   clientRepository,
-		CodeStore:     authCodeRepository,
-		KeyService:    keyService,
-		Issuer:        cfg.IssuerURL,
-		TokenExpiry:   cfg.TokenExpiryMinutes,
-		CodeExpiry:    cfg.CodeExpiryMinutes,
+		ClientStore: clientRepository,
+		CodeStore:   authCodeRepository,
+		CodeExpiry:  cfg.CodeExpiryMinutes,
 	}
 
 	authorizeHandler := oauth2.HttpHandler{

--- a/internal/oauth2/authorize_handler.go
+++ b/internal/oauth2/authorize_handler.go
@@ -5,7 +5,6 @@ import (
 	"barricade/internal/identity"
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
@@ -46,7 +45,7 @@ func (h *HttpHandler) Authorize(w http.ResponseWriter, r *http.Request) error {
 	}
 
 	if err := h.Service.Validate(params); err != nil {
-		redirectURL := buildErrorRedirectURL(redirectURI, mapErrorToCode(err), err.Error(), params.ResponseType)
+		redirectURL := buildErrorRedirectURL(redirectURI, mapErrorToCode(err), err.Error())
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return nil
 	}
@@ -59,27 +58,14 @@ func (h *HttpHandler) Authorize(w http.ResponseWriter, r *http.Request) error {
 		return nil
 	}
 
-	if params.ResponseType == string(ResponseTypeCode) {
-		code, err := h.Service.GenerateCode(ctx, identity.Id(identityId), params)
-		if err != nil {
-			redirectURL := buildErrorRedirectURL(redirectURI, "server_error", "failed to generate code", params.ResponseType)
-			http.Redirect(w, r, redirectURL, http.StatusFound)
-			return nil
-		}
-
-		redirectURL := buildCodeRedirectURL(redirectURI, code, params.State)
-		http.Redirect(w, r, redirectURL, http.StatusFound)
-		return nil
-	}
-
-	result, err := h.Service.Authorize(ctx, identity.Id(identityId), params.ClientId)
+	code, err := h.Service.GenerateCode(ctx, identity.Id(identityId), params)
 	if err != nil {
-		redirectURL := buildErrorRedirectURL(redirectURI, "server_error", "failed to generate token", params.ResponseType)
+		redirectURL := buildErrorRedirectURL(redirectURI, "server_error", "failed to generate code")
 		http.Redirect(w, r, redirectURL, http.StatusFound)
 		return nil
 	}
 
-	redirectURL := buildSuccessRedirectURL(redirectURI, result, h.Service.TokenExpiry, params.State)
+	redirectURL := buildCodeRedirectURL(redirectURI, code, params.State)
 	http.Redirect(w, r, redirectURL, http.StatusFound)
 	return nil
 }
@@ -113,25 +99,6 @@ func (h *HttpHandler) buildLoginRedirectURL(r *http.Request) string {
 	return u.String()
 }
 
-func buildSuccessRedirectURL(redirectURI string, result *AuthorizationResult, tokenExpiry int, state string) string {
-	u, err := url.Parse(redirectURI)
-	if err != nil {
-		return redirectURI
-	}
-
-	fragment := url.Values{}
-	fragment.Set("id_token", string(result.IDToken))
-	fragment.Set("token_type", "Bearer")
-	fragment.Set("expires_in", fmt.Sprintf("%d", tokenExpiry*60))
-	if state != "" {
-		fragment.Set("state", state)
-	}
-
-	u.Fragment = fragment.Encode()
-
-	return u.String()
-}
-
 func buildCodeRedirectURL(redirectURI string, code string, state string) string {
 	u, err := url.Parse(redirectURI)
 	if err != nil {
@@ -148,27 +115,18 @@ func buildCodeRedirectURL(redirectURI string, code string, state string) string 
 	return u.String()
 }
 
-func buildErrorRedirectURL(redirectURI string, errorCode string, errorDescription string, responseType string) string {
+func buildErrorRedirectURL(redirectURI string, errorCode string, errorDescription string) string {
 	u, err := url.Parse(redirectURI)
 	if err != nil {
 		return redirectURI
 	}
 
-	values := url.Values{}
-	values.Set("error", errorCode)
+	q := u.Query()
+	q.Set("error", errorCode)
 	if errorDescription != "" {
-		values.Set("error_description", errorDescription)
+		q.Set("error_description", errorDescription)
 	}
-
-	if responseType == string(ResponseTypeCode) {
-		q := u.Query()
-		for k, v := range values {
-			q[k] = v
-		}
-		u.RawQuery = q.Encode()
-	} else {
-		u.Fragment = values.Encode()
-	}
+	u.RawQuery = q.Encode()
 
 	return u.String()
 }

--- a/internal/oauth2/authorize_handler_test.go
+++ b/internal/oauth2/authorize_handler_test.go
@@ -6,48 +6,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestBuildSuccessRedirectURL(t *testing.T) {
-	result := &AuthorizationResult{
-		IDToken: "test-id-token",
-	}
-
-	redirectURL := buildSuccessRedirectURL("https://example.com/callback", result, 5, "")
-
-	assert.Contains(t, redirectURL, "https://example.com/callback")
-	assert.Contains(t, redirectURL, "id_token=test-id-token")
-	assert.Contains(t, redirectURL, "token_type=Bearer")
-	assert.Contains(t, redirectURL, "expires_in=300")
-	assert.Contains(t, redirectURL, "#")
-}
-
 func TestBuildErrorRedirectURL(t *testing.T) {
-	redirectURL := buildErrorRedirectURL("https://example.com/callback", "invalid_request", "missing parameter", string(ResponseTypeIdToken))
+	redirectURL := buildErrorRedirectURL("https://example.com/callback", "invalid_request", "missing parameter")
 
 	assert.Contains(t, redirectURL, "https://example.com/callback")
 	assert.Contains(t, redirectURL, "error=invalid_request")
 	assert.Contains(t, redirectURL, "error_description=missing+parameter")
-	assert.Contains(t, redirectURL, "#")
 }
 
 func TestBuildErrorRedirectURLEmptyDescription(t *testing.T) {
-	redirectURL := buildErrorRedirectURL("https://example.com/callback", "invalid_scope", "", string(ResponseTypeIdToken))
+	redirectURL := buildErrorRedirectURL("https://example.com/callback", "invalid_scope", "")
 
 	assert.Contains(t, redirectURL, "error=invalid_scope")
 	assert.NotContains(t, redirectURL, "error_description")
 }
 
-func TestBuildSuccessRedirectURLInvalidURI(t *testing.T) {
-	result := &AuthorizationResult{
-		IDToken: "test-id-token",
-	}
-
-	redirectURL := buildSuccessRedirectURL("://invalid-url", result, 5, "")
-
-	assert.Equal(t, "://invalid-url", redirectURL)
-}
-
 func TestBuildErrorRedirectURLInvalidURI(t *testing.T) {
-	redirectURL := buildErrorRedirectURL("://invalid-url", "invalid_request", "missing parameter", string(ResponseTypeIdToken))
+	redirectURL := buildErrorRedirectURL("://invalid-url", "invalid_request", "missing parameter")
 
 	assert.Equal(t, "://invalid-url", redirectURL)
 }

--- a/internal/oauth2/authorize_service.go
+++ b/internal/oauth2/authorize_service.go
@@ -2,8 +2,6 @@ package oauth2
 
 import (
 	"barricade/internal/identity"
-	"barricade/internal/keys"
-	"barricade/internal/oidc"
 	"context"
 	"crypto/rand"
 	"encoding/hex"
@@ -18,9 +16,8 @@ type (
 )
 
 const (
-	ResponseTypeIdToken responseType = "id_token"
-	ResponseTypeCode    responseType = "code"
-	ScopeOpenID         scope        = "openid"
+	ResponseTypeCode responseType = "code"
+	ScopeOpenID      scope        = "openid"
 )
 
 type IdentityRepository interface {
@@ -38,18 +35,10 @@ type (
 		CodeChallengeMethod string
 	}
 
-	AuthorizationResult struct {
-		IDToken oidc.IdToken
-	}
-
 	AuthorizeService struct {
-		IdentityStore IdentityRepository
-		ClientStore   ClientRepository
-		CodeStore     AuthorizationCodeRepository
-		KeyService    *keys.Service
-		Issuer        string
-		TokenExpiry   int
-		CodeExpiry    int
+		ClientStore ClientRepository
+		CodeStore   AuthorizationCodeRepository
+		CodeExpiry  int
 	}
 )
 
@@ -84,7 +73,7 @@ func (s *AuthorizeService) Validate(params AuthorizationParams) error {
 		return ErrInvalidRequest
 	}
 
-	if !strings.Contains(params.ResponseType, string(ResponseTypeIdToken)) && params.ResponseType != string(ResponseTypeCode) {
+	if params.ResponseType != string(ResponseTypeCode) {
 		return ErrUnsupportedResponseType
 	}
 
@@ -115,33 +104,6 @@ func (s *AuthorizeService) Validate(params AuthorizationParams) error {
 func isValidCodeChallenge(challenge string) bool {
 	l := len(challenge)
 	return l >= 43 && l <= 128
-}
-
-func (s *AuthorizeService) Authorize(ctx context.Context, identityId identity.Id, clientId string) (*AuthorizationResult, error) {
-	ident, err := s.IdentityStore.FindById(ctx, identityId)
-	if err != nil {
-		return nil, err
-	}
-
-	key, err := s.KeyService.GetSigningKey(ctx, keys.RS256)
-	if err != nil {
-		return nil, ErrServerError
-	}
-
-	token, err := oidc.NewIdToken(oidc.IdTokenParams{
-		Key:           key,
-		Ident:         ident,
-		ClientId:      clientId,
-		Issuer:        s.Issuer,
-		ExpiryMinutes: s.TokenExpiry,
-	})
-	if err != nil {
-		return nil, ErrServerError
-	}
-
-	return &AuthorizationResult{
-		IDToken: token,
-	}, nil
 }
 
 func (s *AuthorizeService) GenerateCode(ctx context.Context, identityId identity.Id, params AuthorizationParams) (string, error) {

--- a/internal/oauth2/authorize_service_test.go
+++ b/internal/oauth2/authorize_service_test.go
@@ -260,13 +260,9 @@ func setupOAuth2Module(t *testing.T) *oauth2Module {
 	assert.NoError(t, err)
 
 	authorizeService := &AuthorizeService{
-		IdentityStore: identityStore,
-		ClientStore:   clientRepository,
-		CodeStore:     authCodeRepository,
-		KeyService:    keyService,
-		Issuer:        "https://test.issuer.com",
-		TokenExpiry:   5,
-		CodeExpiry:    5,
+		ClientStore: clientRepository,
+		CodeStore:   authCodeRepository,
+		CodeExpiry:  5,
 	}
 
 	authService := &authentication.Service{
@@ -400,29 +396,6 @@ func TestAuthorizeServiceGenerateCodeWithPKCEDefaultsMethod(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM", stored.CodeChallenge)
 	assert.Equal(t, "S256", stored.CodeChallengeMethod)
-}
-
-func TestAuthorizeServiceAuthorizeHappyPath(t *testing.T) {
-	module := setupOAuth2Module(t)
-
-	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
-	assert.NoError(t, err)
-
-	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
-		OwnerId:     string(ident.Id),
-		Name:        "test-app",
-		Domain:      "example.com",
-		RedirectURI: "https://example.com/callback",
-	})
-	assert.NoError(t, err)
-
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-
-	result, err := module.authorizeService.Authorize(ctx, ident.Id, string(clientResult.Client.Id))
-	assert.NoError(t, err)
-	assert.NotEmpty(t, result.IDToken)
-	assert.NotNil(t, result)
 }
 
 func TestValidateClientRedirectUnregisteredClient(t *testing.T) {

--- a/internal/oauth2/authorize_service_validation_test.go
+++ b/internal/oauth2/authorize_service_validation_test.go
@@ -33,24 +33,12 @@ func TestAuthorizeServiceValidateMissingOpenIDScope(t *testing.T) {
 	svc := &AuthorizeService{}
 
 	err := svc.Validate(AuthorizationParams{
-		ResponseType: "id_token",
+		ResponseType: "code",
 		ClientId:     "test-client",
 		Scope:        "profile email",
 	})
 
 	assert.ErrorIs(t, err, ErrInvalidScope)
-}
-
-func TestAuthorizeServiceValidateHappyPath(t *testing.T) {
-	svc := &AuthorizeService{}
-
-	err := svc.Validate(AuthorizationParams{
-		ResponseType: "id_token",
-		ClientId:     "test-client",
-		Scope:        "openid profile",
-	})
-
-	assert.NoError(t, err)
 }
 
 func TestAuthorizeServiceValidateCodeResponseType(t *testing.T) {
@@ -139,16 +127,4 @@ func TestAuthorizeServiceValidatePKCEChallengeTooLong(t *testing.T) {
 	assert.ErrorIs(t, err, ErrInvalidCodeChallenge)
 }
 
-func TestAuthorizeServiceValidatePKCEIgnoresForIdToken(t *testing.T) {
-	svc := &AuthorizeService{}
 
-	err := svc.Validate(AuthorizationParams{
-		ResponseType:        "id_token",
-		ClientId:            "test-client",
-		Scope:               "openid",
-		CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
-		CodeChallengeMethod: "S256",
-	})
-
-	assert.NoError(t, err)
-}


### PR DESCRIPTION
Remove the deprecated implicit flow (response_type=id_token). Only the authorization code flow (response_type=code) is now supported.

## Changes
- Removed ResponseTypeIdToken, AuthorizationResult, and Authorize() method from authorize service
- Simplified authorize handler to only handle code flow
- Removed buildSuccessRedirectURL function
- Simplified buildErrorRedirectURL to no longer branch on response type
- Updated tests: removed implicit flow tests, adjusted existing tests to use code response type

## Verification
- All authorize validation unit tests pass (12 tests)
- All token handler integration tests pass (7 tests)
- go vet ./... passes with no issues