### PR TITLE
feat: add state and nonce support to authorization code flow

### DIFF
--- a/internal/oauth2/authorization_code.go
+++ b/internal/oauth2/authorization_code.go
@@ -8,6 +8,8 @@ type AuthorizationCode struct {
 	IdentityId          string
 	RedirectURI         string
 	Scope               string
+	Nonce               string
+	State               string
 	CodeChallenge       string
 	CodeChallengeMethod string
 	CreatedAt           int64

--- a/internal/oauth2/authorization_code_repository.go
+++ b/internal/oauth2/authorization_code_repository.go
@@ -20,6 +20,8 @@ type authCodeDDB struct {
 	ClientId            string `dynamodbav:"clientId"`
 	RedirectURI         string `dynamodbav:"redirectURI"`
 	Scope               string `dynamodbav:"scope"`
+	Nonce               string `dynamodbav:"nonce,omitempty"`
+	State               string `dynamodbav:"state,omitempty"`
 	CodeChallenge       string `dynamodbav:"codeChallenge,omitempty"`
 	CodeChallengeMethod string `dynamodbav:"codeChallengeMethod,omitempty"`
 	CreatedAt           int64  `dynamodbav:"createdAt"`
@@ -55,6 +57,8 @@ func (r *DynamoDBAuthorizationCodeRepository) Save(ctx context.Context, code *Au
 		ClientId:            code.ClientId,
 		RedirectURI:         code.RedirectURI,
 		Scope:               code.Scope,
+		Nonce:               code.Nonce,
+		State:               code.State,
 		CodeChallenge:       code.CodeChallenge,
 		CodeChallengeMethod: code.CodeChallengeMethod,
 		CreatedAt:           code.CreatedAt,
@@ -104,6 +108,8 @@ func (r *DynamoDBAuthorizationCodeRepository) FindByCode(ctx context.Context, co
 		IdentityId:          dbCode.SecondaryLookup,
 		RedirectURI:         dbCode.RedirectURI,
 		Scope:               dbCode.Scope,
+		Nonce:               dbCode.Nonce,
+		State:               dbCode.State,
 		CodeChallenge:       dbCode.CodeChallenge,
 		CodeChallengeMethod: dbCode.CodeChallengeMethod,
 		CreatedAt:           dbCode.CreatedAt,

--- a/internal/oauth2/authorize_handler.go
+++ b/internal/oauth2/authorize_handler.go
@@ -31,6 +31,7 @@ func (h *HttpHandler) Authorize(w http.ResponseWriter, r *http.Request) error {
 		Scope:               r.URL.Query().Get("scope"),
 		RedirectURI:         r.URL.Query().Get("redirect_uri"),
 		State:               r.URL.Query().Get("state"),
+		Nonce:               r.URL.Query().Get("nonce"),
 		CodeChallenge:       r.URL.Query().Get("code_challenge"),
 		CodeChallengeMethod: r.URL.Query().Get("code_challenge_method"),
 	}

--- a/internal/oauth2/authorize_service.go
+++ b/internal/oauth2/authorize_service.go
@@ -31,6 +31,7 @@ type (
 		Scope               string
 		RedirectURI         string
 		State               string
+		Nonce               string
 		CodeChallenge       string
 		CodeChallengeMethod string
 	}
@@ -119,6 +120,8 @@ func (s *AuthorizeService) GenerateCode(ctx context.Context, identityId identity
 
 	authCode := NewAuthorizationCode(params.ClientId, string(identityId), params.RedirectURI, params.Scope, s.CodeExpiry)
 	authCode.Code = code
+	authCode.State = params.State
+	authCode.Nonce = params.Nonce
 	authCode.CodeChallenge = params.CodeChallenge
 	authCode.CodeChallengeMethod = method
 

--- a/internal/oauth2/authorize_service_test.go
+++ b/internal/oauth2/authorize_service_test.go
@@ -398,6 +398,39 @@ func TestAuthorizeServiceGenerateCodeWithPKCEDefaultsMethod(t *testing.T) {
 	assert.Equal(t, "S256", stored.CodeChallengeMethod)
 }
 
+func TestAuthorizeServiceGenerateCodeWithStateAndNonce(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     string(ident.Id),
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	code, err := module.authorizeService.GenerateCode(ctx, ident.Id, AuthorizationParams{
+		ClientId:    string(clientResult.Client.Id),
+		RedirectURI: "https://example.com/callback",
+		Scope:       "openid",
+		State:       "test-state-value",
+		Nonce:       "test-nonce-value",
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, code)
+
+	stored, err := module.authCodeRepository.FindByCode(ctx, code)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-state-value", stored.State)
+	assert.Equal(t, "test-nonce-value", stored.Nonce)
+}
+
 func TestValidateClientRedirectUnregisteredClient(t *testing.T) {
 	module := setupOAuth2Module(t)
 

--- a/internal/oauth2/token_service.go
+++ b/internal/oauth2/token_service.go
@@ -101,6 +101,7 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		Ident:         ident,
 		ClientId:      params.ClientId,
 		Issuer:        s.Issuer,
+		Nonce:         authCode.Nonce,
 		ExpiryMinutes: s.TokenExpiry,
 	})
 	if err != nil {

--- a/internal/oauth2/token_service_test.go
+++ b/internal/oauth2/token_service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -579,4 +580,80 @@ func TestTokenExchangeCodeReplay(t *testing.T) {
 		ClientSecret: string(clientResult.ClientSecret),
 	})
 	assert.ErrorIs(t, err, ErrInvalidCode)
+}
+
+func TestTokenExchangeWithNonce(t *testing.T) {
+	module := setupTokenModule(t)
+
+	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     string(ident.Id),
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	code := NewAuthorizationCode(string(clientResult.Client.Id), string(ident.Id), "https://example.com/callback", "openid", 5)
+	code.Code = "nonce-code-123"
+	code.Nonce = "test-nonce-value"
+	err = module.authCodeRepository.Save(context.Background(), code)
+	assert.NoError(t, err)
+
+	result, err := module.tokenService.Exchange(context.Background(), ExchangeTokenParams{
+		GrantType:    "authorization_code",
+		Code:         "nonce-code-123",
+		RedirectURI:  "https://example.com/callback",
+		ClientId:     string(clientResult.Client.Id),
+		ClientSecret: string(clientResult.ClientSecret),
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result.IDToken)
+
+	token, _, err := jwt.NewParser().ParseUnverified(result.IDToken, jwt.MapClaims{})
+	assert.NoError(t, err)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+	assert.Equal(t, "test-nonce-value", claims["nonce"])
+}
+
+func TestTokenExchangeWithoutNonce(t *testing.T) {
+	module := setupTokenModule(t)
+
+	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     string(ident.Id),
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	code := NewAuthorizationCode(string(clientResult.Client.Id), string(ident.Id), "https://example.com/callback", "openid", 5)
+	code.Code = "no-nonce-code-123"
+	err = module.authCodeRepository.Save(context.Background(), code)
+	assert.NoError(t, err)
+
+	result, err := module.tokenService.Exchange(context.Background(), ExchangeTokenParams{
+		GrantType:    "authorization_code",
+		Code:         "no-nonce-code-123",
+		RedirectURI:  "https://example.com/callback",
+		ClientId:     string(clientResult.Client.Id),
+		ClientSecret: string(clientResult.ClientSecret),
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result.IDToken)
+
+	token, _, err := jwt.NewParser().ParseUnverified(result.IDToken, jwt.MapClaims{})
+	assert.NoError(t, err)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+	_, hasNonce := claims["nonce"]
+	assert.False(t, hasNonce)
 }

--- a/internal/oidc/id_token.go
+++ b/internal/oidc/id_token.go
@@ -17,6 +17,7 @@ type (
 		Ident         *identity.Identity
 		ClientId      string
 		Issuer        string
+		Nonce         string
 		ExpiryMinutes int
 	}
 )
@@ -36,6 +37,10 @@ func NewIdToken(params IdTokenParams) (IdToken, error) {
 		"aud": params.ClientId,
 		"exp": exp.Unix(),
 		"iat": now.Unix(),
+	}
+
+	if params.Nonce != "" {
+		claims["nonce"] = params.Nonce
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)


### PR DESCRIPTION
Add support for the `state` and `nonce` parameters in the OIDC authorization flow.

## Changes
- Added `Nonce` and `State` fields to `AuthorizationParams` (parsed from authorize request)
- Added `Nonce` and `State` fields to `AuthorizationCode` model and DynamoDB persistence DTO
- Added `nonce` claim to ID Token when `nonce` is provided in the authorization request
- Piped `nonce` through the full flow: authorize request → stored with authorization code → exchanged at token endpoint → emitted in ID Token claims

## Verification
- Added `TestAuthorizeServiceGenerateCodeWithStateAndNonce` test verifying state/nonce are stored in DynamoDB
- Added `TestTokenExchangeWithNonce` test verifying nonce claim appears in ID Token
- Added `TestTokenExchangeWithoutNonce` test verifying nonce claim is absent when not requested
- Full test suite passes (`go test ./internal/oauth2/ ./internal/oidc/`)