### PR TITLE
feat: add OIDC discovery endpoint and missing id_token claims

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -90,6 +90,10 @@ func main() {
 		KeyService: keyService,
 	}
 
+	discoveryHandler := oidc.DiscoveryHandler{
+		Issuer: cfg.IssuerURL,
+	}
+
 	authorizeService := oauth2.AuthorizeService{
 		ClientStore: clientRepository,
 		CodeStore:   authCodeRepository,
@@ -130,11 +134,11 @@ func main() {
 		ihttp.BarricadeAuthenticationProvider{
 			AuthenticationService: authNService,
 		},
-		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "GET /.well-known/jwks.json", "GET /v1/oauth2/authorize", "POST /v1/oauth2/token", "GET /v1/oauth2/userinfo"}...)
+		[]string{"GET /health", "POST /v1/login", "POST /v1/register", "GET /.well-known/jwks.json", "GET /.well-known/openid-configuration", "GET /v1/oauth2/authorize", "POST /v1/oauth2/token", "GET /v1/oauth2/userinfo"}...)
 
 	httpServer := xhttp.Server{
 		Addr:     ":8080",
-		Handlers: []xhttp.RouteHandler{&identityHandler, &clientHandler, &authNHandler, &infrastructure.HealthHttpHandler{}, &jwksHandler, &authorizeHandler, &tokenHandler, &userinfoHandler},
+		Handlers: []xhttp.RouteHandler{&identityHandler, &clientHandler, &authNHandler, &infrastructure.HealthHttpHandler{}, &jwksHandler, &discoveryHandler, &authorizeHandler, &tokenHandler, &userinfoHandler},
 		AuthN:    authenticator,
 	}
 

--- a/internal/oauth2/authorization_code.go
+++ b/internal/oauth2/authorization_code.go
@@ -12,6 +12,7 @@ type AuthorizationCode struct {
 	State               string
 	CodeChallenge       string
 	CodeChallengeMethod string
+	AuthTime            int64
 	CreatedAt           int64
 	ExpireAt            int64
 }

--- a/internal/oauth2/authorization_code_repository.go
+++ b/internal/oauth2/authorization_code_repository.go
@@ -24,6 +24,7 @@ type authCodeDDB struct {
 	State               string `dynamodbav:"state,omitempty"`
 	CodeChallenge       string `dynamodbav:"codeChallenge,omitempty"`
 	CodeChallengeMethod string `dynamodbav:"codeChallengeMethod,omitempty"`
+	AuthTime            int64  `dynamodbav:"authTime"`
 	CreatedAt           int64  `dynamodbav:"createdAt"`
 	ExpireAt            int64  `dynamodbav:"expireAt"`
 }
@@ -61,6 +62,7 @@ func (r *DynamoDBAuthorizationCodeRepository) Save(ctx context.Context, code *Au
 		State:               code.State,
 		CodeChallenge:       code.CodeChallenge,
 		CodeChallengeMethod: code.CodeChallengeMethod,
+		AuthTime:            code.AuthTime,
 		CreatedAt:           code.CreatedAt,
 		ExpireAt:            code.ExpireAt,
 	}
@@ -112,6 +114,7 @@ func (r *DynamoDBAuthorizationCodeRepository) FindByCode(ctx context.Context, co
 		State:               dbCode.State,
 		CodeChallenge:       dbCode.CodeChallenge,
 		CodeChallengeMethod: dbCode.CodeChallengeMethod,
+		AuthTime:            dbCode.AuthTime,
 		CreatedAt:           dbCode.CreatedAt,
 		ExpireAt:            dbCode.ExpireAt,
 	}, nil

--- a/internal/oauth2/authorize_service.go
+++ b/internal/oauth2/authorize_service.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"net/url"
 	"strings"
+	"time"
 )
 
 type (
@@ -124,6 +125,7 @@ func (s *AuthorizeService) GenerateCode(ctx context.Context, identityId identity
 	authCode.Nonce = params.Nonce
 	authCode.CodeChallenge = params.CodeChallenge
 	authCode.CodeChallengeMethod = method
+	authCode.AuthTime = time.Now().Unix()
 
 	err = s.CodeStore.Save(ctx, authCode)
 	if err != nil {

--- a/internal/oauth2/token_service.go
+++ b/internal/oauth2/token_service.go
@@ -96,18 +96,6 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		return nil, ErrServerError
 	}
 
-	idToken, err := oidc.NewIdToken(oidc.IdTokenParams{
-		Key:           key,
-		Ident:         ident,
-		ClientId:      params.ClientId,
-		Issuer:        s.Issuer,
-		Nonce:         authCode.Nonce,
-		ExpiryMinutes: s.TokenExpiry,
-	})
-	if err != nil {
-		return nil, ErrServerError
-	}
-
 	accessToken, err := oidc.NewAccessToken(oidc.AccessTokenParams{
 		Key:           key,
 		Ident:         ident,
@@ -115,6 +103,20 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		Issuer:        s.Issuer,
 		Scope:         authCode.Scope,
 		ExpiryMinutes: s.AccessTokenExpiry,
+	})
+	if err != nil {
+		return nil, ErrServerError
+	}
+
+	idToken, err := oidc.NewIdToken(oidc.IdTokenParams{
+		Key:           key,
+		Ident:         ident,
+		ClientId:      params.ClientId,
+		Issuer:        s.Issuer,
+		Nonce:         authCode.Nonce,
+		ExpiryMinutes: s.TokenExpiry,
+		AuthTime:      authCode.AuthTime,
+		AccessToken:   string(accessToken),
 	})
 	if err != nil {
 		return nil, ErrServerError

--- a/internal/oauth2/token_service_test.go
+++ b/internal/oauth2/token_service_test.go
@@ -620,6 +620,56 @@ func TestTokenExchangeWithNonce(t *testing.T) {
 	assert.Equal(t, "test-nonce-value", claims["nonce"])
 }
 
+func TestTokenExchangeIdTokenClaims(t *testing.T) {
+	module := setupTokenModule(t)
+
+	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     string(ident.Id),
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+	})
+	assert.NoError(t, err)
+
+	code := NewAuthorizationCode(string(clientResult.Client.Id), string(ident.Id), "https://example.com/callback", "openid", 5)
+	code.Code = "claims-test-code-123"
+	code.Nonce = "test-nonce"
+	code.AuthTime = 1715000000
+	err = module.authCodeRepository.Save(context.Background(), code)
+	assert.NoError(t, err)
+
+	result, err := module.tokenService.Exchange(context.Background(), ExchangeTokenParams{
+		GrantType:    "authorization_code",
+		Code:         "claims-test-code-123",
+		RedirectURI:  "https://example.com/callback",
+		ClientId:     string(clientResult.Client.Id),
+		ClientSecret: string(clientResult.ClientSecret),
+	})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, result.IDToken)
+
+	token, _, err := jwt.NewParser().ParseUnverified(result.IDToken, jwt.MapClaims{})
+	assert.NoError(t, err)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	assert.True(t, ok)
+
+	assert.Equal(t, "https://test.issuer.com", claims["iss"])
+	assert.Equal(t, string(ident.Id), claims["sub"])
+	assert.Equal(t, string(clientResult.Client.Id), claims["aud"])
+	assert.Equal(t, "test-nonce", claims["nonce"])
+	assert.Equal(t, float64(1715000000), claims["auth_time"])
+	assert.Equal(t, "0", claims["acr"])
+	assert.Equal(t, []interface{}{"pwd"}, claims["amr"])
+
+	atHash, ok := claims["at_hash"].(string)
+	assert.True(t, ok)
+	assert.NotEmpty(t, atHash)
+}
+
 func TestTokenExchangeWithoutNonce(t *testing.T) {
 	module := setupTokenModule(t)
 

--- a/internal/oidc/discovery_handler.go
+++ b/internal/oidc/discovery_handler.go
@@ -1,0 +1,52 @@
+package oidc
+
+import (
+	"net/http"
+
+	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
+)
+
+type DiscoveryResponse struct {
+	Issuer                           string   `json:"issuer"`
+	AuthorizationEndpoint            string   `json:"authorization_endpoint"`
+	TokenEndpoint                    string   `json:"token_endpoint"`
+	UserinfoEndpoint                 string   `json:"userinfo_endpoint"`
+	JWKSUri                          string   `json:"jwks_uri"`
+	ScopesSupported                  []string `json:"scopes_supported"`
+	ResponseTypesSupported           []string `json:"response_types_supported"`
+	ResponseModesSupported           []string `json:"response_modes_supported"`
+	SubjectTypesSupported            []string `json:"subject_types_supported"`
+	IDTokenSigningAlgValuesSupported []string `json:"id_token_signing_alg_values_supported"`
+	ClaimsSupported                  []string `json:"claims_supported"`
+	CodeChallengeMethodsSupported    []string `json:"code_challenge_methods_supported"`
+}
+
+type DiscoveryHandler struct {
+	Issuer string
+}
+
+func (h *DiscoveryHandler) RegisterRoutes(router *xhttp.Router) {
+	router.RegisterHandler("GET /.well-known/openid-configuration", h.GetDiscovery)
+}
+
+func (h *DiscoveryHandler) GetDiscovery(w http.ResponseWriter, r *http.Request) error {
+	response := DiscoveryResponse{
+		Issuer:                h.Issuer,
+		AuthorizationEndpoint: h.Issuer + "/v1/oauth2/authorize",
+		TokenEndpoint:         h.Issuer + "/v1/oauth2/token",
+		UserinfoEndpoint:      h.Issuer + "/v1/oauth2/userinfo",
+		JWKSUri:               h.Issuer + "/.well-known/jwks.json",
+		ScopesSupported:       []string{"openid", "profile"},
+		ResponseTypesSupported: []string{"code"},
+		ResponseModesSupported: []string{"query", "fragment"},
+		SubjectTypesSupported:  []string{"public"},
+		IDTokenSigningAlgValuesSupported: []string{"RS256"},
+		ClaimsSupported: []string{
+			"sub", "name", "iss", "aud", "exp", "iat",
+			"auth_time", "acr", "amr", "nonce",
+		},
+		CodeChallengeMethodsSupported: []string{"S256"},
+	}
+
+	return xhttp.WriteResponse(w, http.StatusOK, response)
+}

--- a/internal/oidc/discovery_handler_test.go
+++ b/internal/oidc/discovery_handler_test.go
@@ -1,0 +1,51 @@
+package oidc
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDiscoveryResponseStructure(t *testing.T) {
+	handler := DiscoveryHandler{
+		Issuer: "https://auth.example.com",
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/.well-known/openid-configuration", nil)
+	w := httptest.NewRecorder()
+
+	err := handler.GetDiscovery(w, req)
+	require.NoError(t, err)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "application/json", resp.Header.Get("Content-Type"))
+
+	var body DiscoveryResponse
+	err = json.NewDecoder(resp.Body).Decode(&body)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://auth.example.com", body.Issuer)
+	assert.Equal(t, "https://auth.example.com/v1/oauth2/authorize", body.AuthorizationEndpoint)
+	assert.Equal(t, "https://auth.example.com/v1/oauth2/token", body.TokenEndpoint)
+	assert.Equal(t, "https://auth.example.com/v1/oauth2/userinfo", body.UserinfoEndpoint)
+	assert.Equal(t, "https://auth.example.com/.well-known/jwks.json", body.JWKSUri)
+
+	assert.Equal(t, []string{"openid", "profile"}, body.ScopesSupported)
+	assert.Equal(t, []string{"code"}, body.ResponseTypesSupported)
+	assert.Equal(t, []string{"query", "fragment"}, body.ResponseModesSupported)
+	assert.Equal(t, []string{"public"}, body.SubjectTypesSupported)
+	assert.Equal(t, []string{"RS256"}, body.IDTokenSigningAlgValuesSupported)
+	assert.Equal(t, []string{"S256"}, body.CodeChallengeMethodsSupported)
+	assert.Contains(t, body.ClaimsSupported, "sub")
+	assert.Contains(t, body.ClaimsSupported, "auth_time")
+	assert.Contains(t, body.ClaimsSupported, "acr")
+	assert.Contains(t, body.ClaimsSupported, "amr")
+	assert.Contains(t, body.ClaimsSupported, "nonce")
+}
+
+

--- a/internal/oidc/id_token.go
+++ b/internal/oidc/id_token.go
@@ -3,6 +3,8 @@ package oidc
 import (
 	"barricade/internal/identity"
 	"barricade/internal/keys"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"time"
 
@@ -19,8 +21,15 @@ type (
 		Issuer        string
 		Nonce         string
 		ExpiryMinutes int
+		AuthTime      int64
+		AccessToken   string
 	}
 )
+
+func atHash(accessToken string) string {
+	hash := sha256.Sum256([]byte(accessToken))
+	return base64.RawURLEncoding.EncodeToString(hash[:16])
+}
 
 func NewIdToken(params IdTokenParams) (IdToken, error) {
 	privateKey, err := params.Key.RSAPrivateKey()
@@ -32,11 +41,18 @@ func NewIdToken(params IdTokenParams) (IdToken, error) {
 	exp := now.Add(time.Duration(params.ExpiryMinutes) * time.Minute)
 
 	claims := jwt.MapClaims{
-		"iss": params.Issuer,
-		"sub": string(params.Ident.Id),
-		"aud": params.ClientId,
-		"exp": exp.Unix(),
-		"iat": now.Unix(),
+		"iss":       params.Issuer,
+		"sub":       string(params.Ident.Id),
+		"aud":       params.ClientId,
+		"exp":       exp.Unix(),
+		"iat":       now.Unix(),
+		"auth_time": params.AuthTime,
+		"acr":       "0",
+		"amr":       []string{"pwd"},
+	}
+
+	if params.AccessToken != "" {
+		claims["at_hash"] = atHash(params.AccessToken)
 	}
 
 	if params.Nonce != "" {

--- a/internal/oidc/id_token_test.go
+++ b/internal/oidc/id_token_test.go
@@ -1,0 +1,149 @@
+package oidc
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"barricade/internal/identity"
+	"barricade/internal/keys"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func setupIdTokenTest(t *testing.T) (*keys.Key, *identity.Identity) {
+	repo := keys.NewInMemoryRepository()
+	service := keys.NewService(repo)
+
+	key, err := service.CreateKey(context.Background(), keys.RS256)
+	require.NoError(t, err)
+
+	ident, err := identity.New("test-user", "secret123")
+	require.NoError(t, err)
+
+	return key, ident
+}
+
+func TestNewIdTokenWithAllClaims(t *testing.T) {
+	key, ident := setupIdTokenTest(t)
+	authTime := time.Now().Unix()
+
+	accessToken := "test-access-token-value"
+	expectedHash := sha256.Sum256([]byte(accessToken))
+	expectedAtHash := base64.RawURLEncoding.EncodeToString(expectedHash[:16])
+
+	idToken, err := NewIdToken(IdTokenParams{
+		Key:           key,
+		Ident:         ident,
+		ClientId:      "test-client-id",
+		Issuer:        "https://issuer.example.com",
+		Nonce:         "test-nonce",
+		ExpiryMinutes: 5,
+		AuthTime:      authTime,
+		AccessToken:   accessToken,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, idToken)
+
+	token, _, err := jwt.NewParser().ParseUnverified(string(idToken), jwt.MapClaims{})
+	require.NoError(t, err)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+
+	assert.Equal(t, "https://issuer.example.com", claims["iss"])
+	assert.Equal(t, string(ident.Id), claims["sub"])
+	assert.Equal(t, "test-client-id", claims["aud"])
+	assert.Equal(t, "test-nonce", claims["nonce"])
+
+	authTimeClaim, ok := claims["auth_time"].(float64)
+	assert.True(t, ok)
+	assert.Equal(t, authTime, int64(authTimeClaim))
+
+	assert.Equal(t, "0", claims["acr"])
+	assert.Equal(t, []interface{}{"pwd"}, claims["amr"])
+
+	assert.Equal(t, expectedAtHash, claims["at_hash"])
+
+	expClaim, ok := claims["exp"].(float64)
+	assert.True(t, ok)
+	assert.Greater(t, expClaim, float64(time.Now().Unix()))
+
+	iatClaim, ok := claims["iat"].(float64)
+	assert.True(t, ok)
+	assert.LessOrEqual(t, iatClaim, float64(time.Now().Unix()))
+}
+
+func TestNewIdTokenWithoutNonceAndAccessToken(t *testing.T) {
+	key, ident := setupIdTokenTest(t)
+
+	idToken, err := NewIdToken(IdTokenParams{
+		Key:           key,
+		Ident:         ident,
+		ClientId:      "test-client-id",
+		Issuer:        "https://issuer.example.com",
+		Nonce:         "",
+		ExpiryMinutes: 5,
+		AuthTime:      0,
+		AccessToken:   "",
+	})
+	require.NoError(t, err)
+
+	token, _, err := jwt.NewParser().ParseUnverified(string(idToken), jwt.MapClaims{})
+	require.NoError(t, err)
+
+	claims, ok := token.Claims.(jwt.MapClaims)
+	require.True(t, ok)
+
+	_, hasNonce := claims["nonce"]
+	assert.False(t, hasNonce)
+
+	_, hasAtHash := claims["at_hash"]
+	assert.False(t, hasAtHash)
+
+	assert.Equal(t, "0", claims["acr"])
+	assert.Equal(t, []interface{}{"pwd"}, claims["amr"])
+
+	authTimeClaim, ok := claims["auth_time"].(float64)
+	assert.True(t, ok)
+	assert.Equal(t, float64(0), authTimeClaim)
+}
+
+func TestAtHash(t *testing.T) {
+	accessToken := "my-access-token"
+	hash := sha256.Sum256([]byte(accessToken))
+	expected := base64.RawURLEncoding.EncodeToString(hash[:16])
+
+	result := atHash(accessToken)
+	assert.Equal(t, expected, result)
+}
+
+func TestAtHashDeterministic(t *testing.T) {
+	token := "same-token-value"
+	assert.Equal(t, atHash(token), atHash(token))
+}
+
+func TestNewIdTokenWithKidHeader(t *testing.T) {
+	key, ident := setupIdTokenTest(t)
+
+	idToken, err := NewIdToken(IdTokenParams{
+		Key:           key,
+		Ident:         ident,
+		ClientId:      "client-id",
+		Issuer:        "https://issuer.example.com",
+		ExpiryMinutes: 5,
+		AuthTime:      0,
+	})
+	require.NoError(t, err)
+
+	token, _, err := jwt.NewParser().ParseUnverified(string(idToken), jwt.MapClaims{})
+	require.NoError(t, err)
+
+	kid, ok := token.Header["kid"].(string)
+	assert.True(t, ok)
+	assert.Equal(t, string(key.Id), kid)
+}


### PR DESCRIPTION
Implement OpenID Connect Discovery endpoint and add missing id_token claims (auth_time, at_hash, acr, amr).

## Changes
- New `DiscoveryHandler` serving `/.well-known/openid-configuration` with issuer, endpoints, supported scopes, response types, signing algorithms, claims, and PKCE methods
- Added `auth_time`, `at_hash`, `acr` (`"0"`), `amr` (`["pwd"]`) claims to id_token
- `at_hash` computed as left-half of SHA-256 of access_token, base64url-encoded
- `AuthTime` propagated from code generation through DynamoDB persistence to token issuance
- Reversed token creation order (access_token first, then id_token) to compute `at_hash`

## Verification
- Added 5 new unit tests in `internal/oidc/id_token_test.go` covering claims presence, absence (no nonce/access_token), at_hash correctness, determinism, and kid header
- Added `TestDiscoveryResponseStructure` in `internal/oidc/discovery_handler_test.go` verifying all discovery fields
- Added `TestTokenExchangeIdTokenClaims` integration test in `internal/oauth2/token_service_test.go` verifying all id_token claims end-to-end via DynamoDB
- All existing tests pass (oidc package: 11/11)