### PR TITLE
feat: Add public/confidential client type support

### DIFF
--- a/internal/oauth2/authorize_handler.go
+++ b/internal/oauth2/authorize_handler.go
@@ -158,6 +158,8 @@ func mapAuthorizeError(err error) error {
 		return xhttp.NewError(mapErrorToCode(err), http.StatusBadRequest)
 	case errors.Is(err, ErrUnauthorizedClient):
 		return xhttp.NewError("unauthorized client", http.StatusUnauthorized)
+	case errors.Is(err, ErrPKCERequired):
+		return xhttp.NewError("PKCE is required for this client", http.StatusBadRequest)
 	case errors.Is(err, ErrRedirectURIMismatch):
 		return xhttp.NewError("redirect uri mismatch", http.StatusBadRequest)
 	default:

--- a/internal/oauth2/authorize_service.go
+++ b/internal/oauth2/authorize_service.go
@@ -53,6 +53,10 @@ func (s *AuthorizeService) ValidateClientRedirect(ctx context.Context, params Au
 		return nil, "", err
 	}
 
+	if client.Type == ClientTypePublic && params.CodeChallenge == "" {
+		return nil, "", ErrPKCERequired
+	}
+
 	redirectURI := params.RedirectURI
 	if redirectURI == "" {
 		redirectURI = client.RedirectURI

--- a/internal/oauth2/authorize_service_test.go
+++ b/internal/oauth2/authorize_service_test.go
@@ -311,6 +311,7 @@ func TestAuthorizeServiceGenerateCodeHappyPath(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -344,6 +345,7 @@ func TestAuthorizeServiceGenerateCodeWithPKCE(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -377,6 +379,7 @@ func TestAuthorizeServiceGenerateCodeWithPKCEDefaultsMethod(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -409,6 +412,7 @@ func TestAuthorizeServiceGenerateCodeWithStateAndNonce(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -429,6 +433,56 @@ func TestAuthorizeServiceGenerateCodeWithStateAndNonce(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "test-state-value", stored.State)
 	assert.Equal(t, "test-nonce-value", stored.Nonce)
+}
+
+func TestValidateClientRedirectPublicClientWithoutPKCERejected(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	_, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypePublic,
+	})
+	assert.NoError(t, err)
+
+	params := AuthorizationParams{
+		ClientId:    string(clientResult.Client.Id),
+		RedirectURI: "https://example.com/callback",
+	}
+
+	_, _, err = module.authorizeService.ValidateClientRedirect(context.Background(), params)
+	assert.ErrorIs(t, err, ErrPKCERequired)
+}
+
+func TestValidateClientRedirectPublicClientWithPKCEAllowed(t *testing.T) {
+	module := setupOAuth2Module(t)
+
+	_, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypePublic,
+	})
+	assert.NoError(t, err)
+
+	params := AuthorizationParams{
+		ClientId:            string(clientResult.Client.Id),
+		RedirectURI:         "https://example.com/callback",
+		CodeChallenge:       "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM",
+		CodeChallengeMethod: "S256",
+	}
+
+	_, _, err = module.authorizeService.ValidateClientRedirect(context.Background(), params)
+	assert.NoError(t, err)
 }
 
 func TestValidateClientRedirectUnregisteredClient(t *testing.T) {
@@ -454,6 +508,7 @@ func TestValidateClientRedirectRedirectURIDomainMismatch(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -477,6 +532,7 @@ func TestValidateClientRedirectUsesRegisteredURIAsFallback(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -502,6 +558,7 @@ func TestValidateClientRedirectSubdomainAllowed(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 

--- a/internal/oauth2/client.go
+++ b/internal/oauth2/client.go
@@ -14,20 +14,27 @@ import (
 type (
 	ClientId     string
 	ClientSecret string
-
-	Client struct {
-		Id          ClientId
-		OwnerId     string
-		Name        string
-		Domain      string
-		SecretHash  []byte
-		RedirectURI string
-		CreatedAt   int64
-		UpdatedAt   int64
-	}
+	ClientType   string
 )
 
-func NewClient(ownerId string, name string, domain string, redirectURI string) (*Client, ClientSecret, error) {
+const (
+	ClientTypePublic       ClientType = "public"
+	ClientTypeConfidential ClientType = "confidential"
+)
+
+type Client struct {
+	Id          ClientId
+	OwnerId     string
+	Name        string
+	Domain      string
+	SecretHash  []byte
+	RedirectURI string
+	Type        ClientType
+	CreatedAt   int64
+	UpdatedAt   int64
+}
+
+func NewClient(ownerId string, name string, domain string, redirectURI string, clientType ClientType) (*Client, ClientSecret, error) {
 	if ownerId == "" {
 		return nil, "", ErrClientEmptyOwnerId
 	}
@@ -41,6 +48,10 @@ func NewClient(ownerId string, name string, domain string, redirectURI string) (
 		return nil, "", ErrClientEmptyRedirectURI
 	}
 
+	if clientType != ClientTypePublic && clientType != ClientTypeConfidential {
+		return nil, "", ErrInvalidClientType
+	}
+
 	parsedURI, err := url.ParseRequestURI(redirectURI)
 	if err != nil {
 		return nil, "", ErrClientInvalidRedirectURI
@@ -50,14 +61,21 @@ func NewClient(ownerId string, name string, domain string, redirectURI string) (
 		return nil, "", ErrClientRedirectURIDomainMismatch
 	}
 
-	rawSecret, err := generateClientSecret()
-	if err != nil {
-		return nil, "", err
-	}
+	var (
+		rawSecret ClientSecret
+		hash      []byte
+	)
 
-	hash, err := bcrypt.GenerateFromPassword([]byte(rawSecret), 14)
-	if err != nil {
-		return nil, "", err
+	if clientType == ClientTypeConfidential {
+		rawSecret, err = generateClientSecret()
+		if err != nil {
+			return nil, "", err
+		}
+
+		hash, err = bcrypt.GenerateFromPassword([]byte(rawSecret), 14)
+		if err != nil {
+			return nil, "", err
+		}
 	}
 
 	createdAt := time.Now().UnixMilli()
@@ -69,9 +87,10 @@ func NewClient(ownerId string, name string, domain string, redirectURI string) (
 		Domain:      domain,
 		SecretHash:  hash,
 		RedirectURI: redirectURI,
+		Type:        clientType,
 		CreatedAt:   createdAt,
 		UpdatedAt:   createdAt,
-	}, ClientSecret(rawSecret), nil
+	}, rawSecret, nil
 }
 
 func generateClientSecret() (ClientSecret, error) {

--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -14,11 +14,12 @@ type registerClientRequest struct {
 	Name        string `json:"name"`
 	Domain      string `json:"domain"`
 	RedirectURI string `json:"redirectURI"`
+	ClientType  string `json:"clientType"`
 }
 
 type registerClientResponse struct {
 	ClientId     string `json:"clientId"`
-	ClientSecret string `json:"clientSecret"`
+	ClientSecret string `json:"clientSecret,omitempty"`
 }
 
 type listClientResponse struct {
@@ -26,6 +27,7 @@ type listClientResponse struct {
 	Name        string `json:"name"`
 	Domain      string `json:"domain"`
 	RedirectURI string `json:"redirectURI"`
+	Type        string `json:"type"`
 	CreatedAt   int64  `json:"createdAt"`
 	UpdatedAt   int64  `json:"updatedAt"`
 }
@@ -57,6 +59,7 @@ func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) err
 		Name:        request.Name,
 		Domain:      request.Domain,
 		RedirectURI: request.RedirectURI,
+		ClientType:  ClientType(request.ClientType),
 	})
 	if err != nil {
 		return mapClientError(r.Context(), err)
@@ -89,6 +92,7 @@ func (h *ClientHttpHandler) List(w http.ResponseWriter, r *http.Request) error {
 			Name:        c.Name,
 			Domain:      c.Domain,
 			RedirectURI: c.RedirectURI,
+			Type:        string(c.Type),
 			CreatedAt:   c.CreatedAt,
 			UpdatedAt:   c.UpdatedAt,
 		})
@@ -99,6 +103,8 @@ func (h *ClientHttpHandler) List(w http.ResponseWriter, r *http.Request) error {
 
 func mapClientError(ctx context.Context, err error) error {
 	switch {
+	case errors.Is(err, ErrInvalidClientType):
+		return xhttp.NewError("client type must be 'public' or 'confidential'", http.StatusBadRequest)
 	case errors.Is(err, ErrClientEmptyOwnerId):
 		return xhttp.NewError("unauthorized", http.StatusUnauthorized)
 	case errors.Is(err, ErrClientEmptyName):

--- a/internal/oauth2/client_repository.go
+++ b/internal/oauth2/client_repository.go
@@ -25,6 +25,7 @@ type clientDDB struct {
 	Domain            string `dynamodbav:"domain"`
 	SecretHash        []byte `dynamodbav:"secret"`
 	RedirectURI       string `dynamodbav:"redirectURI"`
+	ClientType        string `dynamodbav:"clientType"`
 	CreatedAt         int64  `dynamodbav:"createdAt"`
 	UpdatedAt         int64  `dynamodbav:"updatedAt"`
 }
@@ -45,6 +46,7 @@ func convertClientToDB(c *Client) *clientDDB {
 		Domain:            c.Domain,
 		SecretHash:        c.SecretHash,
 		RedirectURI:       c.RedirectURI,
+		ClientType:        string(c.Type),
 		CreatedAt:         c.CreatedAt,
 		UpdatedAt:         c.UpdatedAt,
 	}
@@ -58,6 +60,7 @@ func convertClientFromDB(db *clientDDB) *Client {
 		Domain:      db.Domain,
 		SecretHash:  db.SecretHash,
 		RedirectURI: db.RedirectURI,
+		Type:        ClientType(db.ClientType),
 		CreatedAt:   db.CreatedAt,
 		UpdatedAt:   db.UpdatedAt,
 	}

--- a/internal/oauth2/client_service.go
+++ b/internal/oauth2/client_service.go
@@ -13,6 +13,7 @@ type RegisterClientParams struct {
 	Name        string
 	Domain      string
 	RedirectURI string
+	ClientType  ClientType
 }
 
 type RegisterClientResult struct {
@@ -25,7 +26,7 @@ type ClientService struct {
 }
 
 func (s *ClientService) Register(ctx context.Context, params RegisterClientParams) (*RegisterClientResult, error) {
-	c, secret, err := NewClient(params.OwnerId, params.Name, params.Domain, params.RedirectURI)
+	c, secret, err := NewClient(params.OwnerId, params.Name, params.Domain, params.RedirectURI, params.ClientType)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/oauth2/client_test.go
+++ b/internal/oauth2/client_test.go
@@ -88,29 +88,57 @@ func setupClientModule(t *testing.T) *clientModule {
 }
 
 func TestClientRegisterEmptyOwnerId(t *testing.T) {
-	_, _, err := NewClient("", TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, TEST_CLIENT_REDIRECT_URI)
+	_, _, err := NewClient("", TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, TEST_CLIENT_REDIRECT_URI, ClientTypeConfidential)
 	assert.ErrorIs(t, err, ErrClientEmptyOwnerId)
 }
 
 func TestClientRegisterInputValidation(t *testing.T) {
-	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, "", TEST_CLIENT_DOMAIN, TEST_CLIENT_REDIRECT_URI)
+	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, "", TEST_CLIENT_DOMAIN, TEST_CLIENT_REDIRECT_URI, ClientTypeConfidential)
 	assert.ErrorIs(t, err, ErrClientEmptyName)
 
-	_, _, err = NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, "", TEST_CLIENT_REDIRECT_URI)
+	_, _, err = NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, "", TEST_CLIENT_REDIRECT_URI, ClientTypeConfidential)
 	assert.ErrorIs(t, err, ErrClientEmptyDomain)
 
-	_, _, err = NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, "")
+	_, _, err = NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, "", ClientTypeConfidential)
 	assert.ErrorIs(t, err, ErrClientEmptyRedirectURI)
 }
 
 func TestClientRegisterInvalidRedirectURI(t *testing.T) {
-	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, "not-a-url")
+	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, "not-a-url", ClientTypeConfidential)
 	assert.ErrorIs(t, err, ErrClientInvalidRedirectURI)
 }
 
 func TestClientRegisterRedirectURIDomainMismatch(t *testing.T) {
-	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, "https://other.com/callback")
+	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, "https://other.com/callback", ClientTypeConfidential)
 	assert.ErrorIs(t, err, ErrClientRedirectURIDomainMismatch)
+}
+
+func TestClientRegisterInvalidClientType(t *testing.T) {
+	_, _, err := NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, TEST_CLIENT_REDIRECT_URI, "invalid")
+	assert.ErrorIs(t, err, ErrInvalidClientType)
+
+	_, _, err = NewClient(TEST_CLIENT_OWNER_ID, TEST_CLIENT_NAME, TEST_CLIENT_DOMAIN, TEST_CLIENT_REDIRECT_URI, ClientType(""))
+	assert.ErrorIs(t, err, ErrInvalidClientType)
+}
+
+func TestClientRegisterPublicClientNoSecret(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypePublic,
+	})
+	assert.NoError(t, err)
+	assert.Empty(t, result.ClientSecret)
+	assert.Nil(t, result.Client.SecretHash)
+	assert.Equal(t, ClientTypePublic, result.Client.Type)
+
+	stored, err := module.repository.FindById(context.Background(), result.Client.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, result.Client, stored)
 }
 
 func TestClientRegisterSubdomainAllowed(t *testing.T) {
@@ -121,6 +149,7 @@ func TestClientRegisterSubdomainAllowed(t *testing.T) {
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: "https://sub.example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 	assert.NotEmpty(t, result.Client.Id)
@@ -134,6 +163,7 @@ func TestClientRegisterHappyPath(t *testing.T) {
 		Name:        TEST_CLIENT_NAME,
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -141,6 +171,7 @@ func TestClientRegisterHappyPath(t *testing.T) {
 	assert.Equal(t, TEST_CLIENT_OWNER_ID, result.Client.OwnerId)
 	assert.Equal(t, TEST_CLIENT_DOMAIN, result.Client.Domain)
 	assert.Equal(t, TEST_CLIENT_REDIRECT_URI, result.Client.RedirectURI)
+	assert.Equal(t, ClientTypeConfidential, result.Client.Type)
 	assert.NotEmpty(t, result.Client.Id)
 	assert.NotEmpty(t, result.ClientSecret)
 	assert.Nil(t, bcrypt.CompareHashAndPassword(result.Client.SecretHash, []byte(result.ClientSecret)))
@@ -167,6 +198,7 @@ func TestClientFindAllHappyPath(t *testing.T) {
 		Name:        "app-1",
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -175,6 +207,7 @@ func TestClientFindAllHappyPath(t *testing.T) {
 		Name:        "app-2",
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -183,6 +216,7 @@ func TestClientFindAllHappyPath(t *testing.T) {
 		Name:        "app-3",
 		Domain:      TEST_CLIENT_DOMAIN,
 		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -29,4 +29,6 @@ var (
 	ErrMissingCodeVerifier             = errors.New("code verifier is required for PKCE authorization code")
 	ErrInvalidToken                    = errors.New("invalid token")
 	ErrInsufficientScope               = errors.New("insufficient scope")
+	ErrInvalidClientType               = errors.New("invalid client type")
+	ErrPKCERequired                    = errors.New("PKCE is required for public clients")
 )

--- a/internal/oauth2/token_handler_test.go
+++ b/internal/oauth2/token_handler_test.go
@@ -24,6 +24,7 @@ func TestTokenHandlerExchangeHappyPath(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -63,6 +64,7 @@ func TestTokenHandlerInvalidClient(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -119,6 +121,7 @@ func TestTokenHandlerExchangeWithBasicAuth(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -159,6 +162,7 @@ func TestTokenHandlerExchangeWithPKCEHappyPath(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -203,6 +207,7 @@ func TestTokenHandlerExchangeBasicAuthWithPKCE(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -240,6 +245,7 @@ func TestTokenHandlerBasicAuthOverridesBody(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 

--- a/internal/oauth2/token_service.go
+++ b/internal/oauth2/token_service.go
@@ -51,6 +51,12 @@ func (s *TokenService) Exchange(ctx context.Context, params ExchangeTokenParams)
 		return nil, err
 	}
 
+	if client.Type == ClientTypePublic {
+		if params.ClientSecret != "" {
+			return nil, ErrInvalidClient
+		}
+	}
+
 	authCode, err := s.CodeStore.FindByCode(ctx, params.Code)
 	if err != nil {
 		return nil, err

--- a/internal/oauth2/token_service_test.go
+++ b/internal/oauth2/token_service_test.go
@@ -266,6 +266,7 @@ func TestTokenExchangeHappyPath(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -308,6 +309,7 @@ func TestTokenExchangeInvalidClient(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -337,6 +339,7 @@ func TestTokenExchangeInvalidCode(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -360,6 +363,7 @@ func TestTokenExchangeExpiredCode(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -389,6 +393,7 @@ func TestTokenExchangeRedirectURIMismatch(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -418,6 +423,7 @@ func TestTokenExchangeWithPKCEHappyPath(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -445,6 +451,41 @@ func TestTokenExchangeWithPKCEHappyPath(t *testing.T) {
 	assert.Equal(t, 3600, result.ExpiresIn)
 }
 
+func TestTokenExchangePublicClientRejectsSecret(t *testing.T) {
+	module := setupTokenModule(t)
+
+	ident, err := module.identityService.Register(context.Background(), TEST_NAME, TEST_SECRET)
+	assert.NoError(t, err)
+
+	clientResult, err := module.clientService.Register(context.Background(), RegisterClientParams{
+		OwnerId:     string(ident.Id),
+		Name:        "test-app",
+		Domain:      "example.com",
+		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypePublic,
+	})
+
+	codeVerifier := "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk"
+	codeChallenge := "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM"
+
+	code := NewAuthorizationCode(string(clientResult.Client.Id), string(ident.Id), "https://example.com/callback", "openid", 5)
+	code.Code = "public-client-with-secret"
+	code.CodeChallenge = codeChallenge
+	code.CodeChallengeMethod = "S256"
+	err = module.authCodeRepository.Save(context.Background(), code)
+	assert.NoError(t, err)
+
+	_, err = module.tokenService.Exchange(context.Background(), ExchangeTokenParams{
+		GrantType:    "authorization_code",
+		Code:         "public-client-with-secret",
+		RedirectURI:  "https://example.com/callback",
+		ClientId:     string(clientResult.Client.Id),
+		ClientSecret: "some-secret",
+		CodeVerifier: codeVerifier,
+	})
+	assert.ErrorIs(t, err, ErrInvalidClient)
+}
+
 func TestTokenExchangeWithPKCEMissingVerifier(t *testing.T) {
 	module := setupTokenModule(t)
 
@@ -456,6 +497,7 @@ func TestTokenExchangeWithPKCEMissingVerifier(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -487,6 +529,7 @@ func TestTokenExchangeWithPKCEInvalidVerifier(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -518,6 +561,7 @@ func TestTokenExchangeWithPKCEPublicClientNoSecret(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypePublic,
 	})
 	assert.NoError(t, err)
 
@@ -555,6 +599,7 @@ func TestTokenExchangeCodeReplay(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -593,6 +638,7 @@ func TestTokenExchangeWithNonce(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -631,6 +677,7 @@ func TestTokenExchangeIdTokenClaims(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 
@@ -681,6 +728,7 @@ func TestTokenExchangeWithoutNonce(t *testing.T) {
 		Name:        "test-app",
 		Domain:      "example.com",
 		RedirectURI: "https://example.com/callback",
+		ClientType:  ClientTypeConfidential,
 	})
 	assert.NoError(t, err)
 


### PR DESCRIPTION
Differentiate between public and confidential clients during registration. Public clients must use PKCE and have no client secret. Confidential clients retain existing behavior.

## Changes
- Added ClientType (public/confidential) to domain model and DynamoDB persistence
- Registration API now requires explicit clientType field
- Public clients: no secret generated, PKCE enforced in authorize flow, client_secret rejected in token exchange
- Confidential clients: secret generated as before, PKCE optional
- Added ErrInvalidClientType and ErrPKCERequired domain errors

## Verification
- Added 5 new tests covering public client registration, invalid client type rejection, PKCE enforcement, and public client secret rejection
- Updated all existing test registration calls with explicit ClientType
- Full test suite (44 tests) passes
- go vet clean