### PR TITLE
fix: Rename clientType JSON field to type

### DIFF
--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -14,7 +14,7 @@ type registerClientRequest struct {
 	Name        string `json:"name"`
 	Domain      string `json:"domain"`
 	RedirectURI string `json:"redirectURI"`
-	ClientType  string `json:"clientType"`
+	ClientType  string `json:"type"`
 }
 
 type registerClientResponse struct {


### PR DESCRIPTION
The registration request JSON field was  but should be  to match the list response and be consistent.

## Changes
- Changed JSON field from  to  in registerClientRequest

## Verification
- Build passes
- Test suite passes