### PR TITLE
feat: add client deletion API

### DIFF
--- a/internal/oauth2/client_handler.go
+++ b/internal/oauth2/client_handler.go
@@ -39,6 +39,7 @@ type ClientHttpHandler struct {
 func (h *ClientHttpHandler) RegisterRoutes(router *xhttp.Router) {
 	router.RegisterHandler("POST /v1/oauth2/clients", h.Register)
 	router.RegisterHandler("GET /v1/oauth2/clients", h.List)
+	router.RegisterHandler("DELETE /v1/oauth2/clients/{id}", h.Delete)
 }
 
 func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) error {
@@ -69,6 +70,21 @@ func (h *ClientHttpHandler) Register(w http.ResponseWriter, r *http.Request) err
 		ClientId:     string(result.Client.Id),
 		ClientSecret: string(result.ClientSecret),
 	})
+}
+
+func (h *ClientHttpHandler) Delete(w http.ResponseWriter, r *http.Request) error {
+	ownerId, ok := r.Context().Value(xhttp.UserId).(string)
+	if !ok || ownerId == "" {
+		return xhttp.NewError("unauthorized", http.StatusUnauthorized)
+	}
+
+	id := ClientId(r.PathValue("id"))
+	err := h.ClientService.Delete(r.Context(), ownerId, id)
+	if err != nil {
+		return mapClientError(r.Context(), err)
+	}
+
+	return xhttp.WriteResponse(w, http.StatusNoContent, nil)
 }
 
 func (h *ClientHttpHandler) List(w http.ResponseWriter, r *http.Request) error {
@@ -119,6 +135,8 @@ func mapClientError(ctx context.Context, err error) error {
 		return xhttp.NewError("redirectURI domain does not match client domain", http.StatusBadRequest)
 	case errors.Is(err, ErrClientNotFound):
 		return xhttp.NewError("client not found", http.StatusNotFound)
+	case errors.Is(err, ErrClientOwnerMismatch):
+		return xhttp.NewError("unauthorized", http.StatusForbidden)
 	default:
 		slog.ErrorContext(ctx, "client service error", "error", err)
 		return xhttp.NewError("unable to register client", http.StatusInternalServerError)

--- a/internal/oauth2/client_handler_test.go
+++ b/internal/oauth2/client_handler_test.go
@@ -23,3 +23,75 @@ func TestClientListEmptyReturnsEmptyList(t *testing.T) {
 	assert.Equal(t, 200, rec.Code)
 	assert.Equal(t, "[]\n", rec.Body.String())
 }
+
+func TestClientDeleteHandlerHappyPath(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
+	})
+	assert.NoError(t, err)
+
+	handler := ClientHttpHandler{ClientService: module.service}
+
+	ctx := context.WithValue(context.Background(), xhttp.UserId, TEST_CLIENT_OWNER_ID)
+	req := httptest.NewRequest("DELETE", "/v1/oauth2/clients/"+string(result.Client.Id), nil).WithContext(ctx)
+	req.SetPathValue("id", string(result.Client.Id))
+	rec := httptest.NewRecorder()
+
+	err = handler.Delete(rec, req)
+	assert.NoError(t, err)
+	assert.Equal(t, 204, rec.Code)
+
+	_, err = module.repository.FindById(context.Background(), result.Client.Id)
+	assert.ErrorIs(t, err, ErrClientNotFound)
+}
+
+func TestClientDeleteUnauthorizedWhenNoUserId(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
+	})
+	assert.NoError(t, err)
+
+	handler := ClientHttpHandler{ClientService: module.service}
+
+	req := httptest.NewRequest("DELETE", "/v1/oauth2/clients/"+string(result.Client.Id), nil)
+	req.SetPathValue("id", string(result.Client.Id))
+	rec := httptest.NewRecorder()
+
+	err = handler.Delete(rec, req)
+	assert.Error(t, err)
+}
+
+func TestClientDeleteForbiddenWhenOwnerMismatch(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
+	})
+	assert.NoError(t, err)
+
+	handler := ClientHttpHandler{ClientService: module.service}
+
+	ctx := context.WithValue(context.Background(), xhttp.UserId, "other-owner")
+	req := httptest.NewRequest("DELETE", "/v1/oauth2/clients/"+string(result.Client.Id), nil).WithContext(ctx)
+	req.SetPathValue("id", string(result.Client.Id))
+	rec := httptest.NewRecorder()
+
+	err = handler.Delete(rec, req)
+	assert.Error(t, err)
+}

--- a/internal/oauth2/client_repository.go
+++ b/internal/oauth2/client_repository.go
@@ -124,6 +124,15 @@ func (r *DynamoDBClientRepository) FindById(ctx context.Context, id ClientId) (*
 	return convertClientFromDB(&dbEntity), nil
 }
 
+func (r *DynamoDBClientRepository) Delete(ctx context.Context, id ClientId) error {
+	_, err := r.Client.DeleteItem(ctx, &dynamodb.DeleteItemInput{
+		TableName: r.Table,
+		Key:       clientKey(id),
+	})
+
+	return err
+}
+
 func (r *DynamoDBClientRepository) FindAll(ctx context.Context) ([]*Client, error) {
 	var result []*Client
 

--- a/internal/oauth2/client_service.go
+++ b/internal/oauth2/client_service.go
@@ -6,6 +6,7 @@ type ClientRepository interface {
 	Save(ctx context.Context, client *Client) error
 	FindById(ctx context.Context, id ClientId) (*Client, error)
 	FindAll(ctx context.Context) ([]*Client, error)
+	Delete(ctx context.Context, id ClientId) error
 }
 
 type RegisterClientParams struct {
@@ -48,4 +49,17 @@ func (s *ClientService) FindById(ctx context.Context, id ClientId) (*Client, err
 
 func (s *ClientService) FindAll(ctx context.Context) ([]*Client, error) {
 	return s.Repo.FindAll(ctx)
+}
+
+func (s *ClientService) Delete(ctx context.Context, ownerId string, id ClientId) error {
+	client, err := s.Repo.FindById(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	if client.OwnerId != ownerId {
+		return ErrClientOwnerMismatch
+	}
+
+	return s.Repo.Delete(ctx, id)
 }

--- a/internal/oauth2/client_test.go
+++ b/internal/oauth2/client_test.go
@@ -190,6 +190,52 @@ func TestClientFindByIdNotFound(t *testing.T) {
 	assert.ErrorIs(t, err, ErrClientNotFound)
 }
 
+func TestClientDeleteHappyPath(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
+	})
+	assert.NoError(t, err)
+
+	err = module.service.Delete(context.Background(), TEST_CLIENT_OWNER_ID, result.Client.Id)
+	assert.NoError(t, err)
+
+	_, err = module.repository.FindById(context.Background(), result.Client.Id)
+	assert.ErrorIs(t, err, ErrClientNotFound)
+}
+
+func TestClientDeleteNotFound(t *testing.T) {
+	module := setupClientModule(t)
+
+	err := module.service.Delete(context.Background(), TEST_CLIENT_OWNER_ID, "nonexistent")
+	assert.ErrorIs(t, err, ErrClientNotFound)
+}
+
+func TestClientDeleteOwnerMismatch(t *testing.T) {
+	module := setupClientModule(t)
+
+	result, err := module.service.Register(context.Background(), RegisterClientParams{
+		OwnerId:     TEST_CLIENT_OWNER_ID,
+		Name:        TEST_CLIENT_NAME,
+		Domain:      TEST_CLIENT_DOMAIN,
+		RedirectURI: TEST_CLIENT_REDIRECT_URI,
+		ClientType:  ClientTypeConfidential,
+	})
+	assert.NoError(t, err)
+
+	err = module.service.Delete(context.Background(), "other-owner", result.Client.Id)
+	assert.ErrorIs(t, err, ErrClientOwnerMismatch)
+
+	stored, err := module.repository.FindById(context.Background(), result.Client.Id)
+	assert.NoError(t, err)
+	assert.Equal(t, result.Client, stored)
+}
+
 func TestClientFindAllHappyPath(t *testing.T) {
 	module := setupClientModule(t)
 

--- a/internal/oauth2/errors.go
+++ b/internal/oauth2/errors.go
@@ -31,4 +31,5 @@ var (
 	ErrInsufficientScope               = errors.New("insufficient scope")
 	ErrInvalidClientType               = errors.New("invalid client type")
 	ErrPKCERequired                    = errors.New("PKCE is required for public clients")
+	ErrClientOwnerMismatch             = errors.New("client owner mismatch")
 )


### PR DESCRIPTION
## Summary\n\n- Add `DELETE /v1/oauth2/clients/{id}` endpoint to delete a client\n- Includes ownership verification — only the client owner can delete\n- Returns `204 No Content` on success, `404` if not found, `403` if not the owner\n\n## Changes\n\n- `client_service.go` — added `Delete` to repository interface and service\n- `client_repository.go` — hard delete via DynamoDB `DeleteItem`\n- `client_handler.go` — route registration, handler, and error mapping\n- `errors.go` — added `ErrClientOwnerMismatch`\n- `client_test.go` / `client_handler_test.go` — 6 new tests covering happy path, not found, unauthorized, and owner mismatch