### PR TITLE
feat: add sharded-type index for identities and list endpoint

### DIFF
--- a/internal/identity/identity_handler.go
+++ b/internal/identity/identity_handler.go
@@ -28,6 +28,7 @@ type HttpHandler struct {
 
 func (handler *HttpHandler) RegisterRoutes(router *xhttp.Router) {
 	router.RegisterHandler("POST /v1/register", handler.Register)
+	router.RegisterHandler("GET /v1/identities", handler.List)
 }
 
 func (handler *HttpHandler) Register(w http.ResponseWriter, r *http.Request) error {
@@ -51,6 +52,25 @@ func (handler *HttpHandler) Register(w http.ResponseWriter, r *http.Request) err
 	}
 
 	return xhttp.WriteResponse(w, http.StatusCreated, dto)
+}
+
+func (handler *HttpHandler) List(w http.ResponseWriter, r *http.Request) error {
+	entities, err := handler.Service.FindAll(r.Context())
+	if err != nil {
+		return mapIdentityError(r.Context(), err)
+	}
+
+	response := make([]IdentityResponse, 0, len(entities))
+	for _, entity := range entities {
+		response = append(response, IdentityResponse{
+			ID:        entity.Id,
+			Name:      entity.Name,
+			UpdatedAt: entity.UpdatedAt,
+			CreatedAt: entity.CreatedAt,
+		})
+	}
+
+	return xhttp.WriteResponse(w, http.StatusOK, response)
 }
 
 func mapIdentityError(ctx context.Context, err error) error {

--- a/internal/identity/identity_handler_test.go
+++ b/internal/identity/identity_handler_test.go
@@ -1,0 +1,25 @@
+package identity
+
+import (
+	"context"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/VaynerAkaWalo/go-toolkit/xhttp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIdentityListEmptyReturnsEmptyList(t *testing.T) {
+	module := setupModule(t)
+
+	handler := HttpHandler{Service: module.service}
+
+	ctx := context.WithValue(context.Background(), xhttp.UserId, "test-user")
+	req := httptest.NewRequest("GET", "/v1/identities", nil).WithContext(ctx)
+	rec := httptest.NewRecorder()
+
+	err := handler.List(rec, req)
+	assert.NoError(t, err)
+	assert.Equal(t, 200, rec.Code)
+	assert.Equal(t, "[]\n", rec.Body.String())
+}

--- a/internal/identity/identity_service.go
+++ b/internal/identity/identity_service.go
@@ -7,10 +7,15 @@ import (
 type Repository interface {
 	Save(ctx context.Context, identity *Identity) error
 	FindById(ctx context.Context, id Id) (*Identity, error)
+	FindAll(ctx context.Context) ([]*Identity, error)
 }
 
 type Service struct {
 	Repo Repository
+}
+
+func (s *Service) FindAll(ctx context.Context) ([]*Identity, error) {
+	return s.Repo.FindAll(ctx)
 }
 
 func (s *Service) Register(ctx context.Context, name string, secret string) (*Identity, error) {

--- a/internal/identity/identity_test.go
+++ b/internal/identity/identity_test.go
@@ -88,6 +88,10 @@ func setupModule(t *testing.T) *identityModule {
 					AttributeName: aws.String("secondary-lookup-sk"),
 					AttributeType: types.ScalarAttributeTypeS,
 				},
+				{
+					AttributeName: aws.String("sharded-type"),
+					AttributeType: types.ScalarAttributeTypeS,
+				},
 			},
 			GlobalSecondaryIndexes: []types.GlobalSecondaryIndex{
 				{
@@ -106,6 +110,22 @@ func setupModule(t *testing.T) *identityModule {
 						ProjectionType: types.ProjectionTypeAll,
 					},
 				},
+				{
+					IndexName: aws.String("sharded-type-index"),
+					KeySchema: []types.KeySchemaElement{
+						{
+							AttributeName: aws.String("sharded-type"),
+							KeyType:       types.KeyTypeHash,
+						},
+						{
+							AttributeName: aws.String("id"),
+							KeyType:       types.KeyTypeRange,
+						},
+					},
+					Projection: &types.Projection{
+						ProjectionType: types.ProjectionTypeAll,
+					},
+				},
 			},
 			BillingMode: types.BillingModePayPerRequest,
 		})
@@ -116,6 +136,7 @@ func setupModule(t *testing.T) *identityModule {
 		Client:               client,
 		Table:                aws.String("test_identity_table"),
 		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
+		ShardedTypeIndex:     aws.String("sharded-type-index"),
 	}
 
 	return &identityModule{
@@ -150,4 +171,21 @@ func TestRegisterHappyPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, res, entity)
+}
+
+func TestIdentityFindAllHappyPath(t *testing.T) {
+	module := setupModule(t)
+
+	_, err := module.service.Register(context.Background(), "user-1", TEST_SECRET)
+	assert.NoError(t, err)
+
+	_, err = module.service.Register(context.Background(), "user-2", TEST_SECRET)
+	assert.NoError(t, err)
+
+	_, err = module.service.Register(context.Background(), "user-3", TEST_SECRET)
+	assert.NoError(t, err)
+
+	identities, err := module.service.FindAll(context.Background())
+	assert.NoError(t, err)
+	assert.Len(t, identities, 3)
 }

--- a/internal/identity/repository.go
+++ b/internal/identity/repository.go
@@ -3,8 +3,10 @@ package identity
 import (
 	"context"
 	"fmt"
+	"hash/crc32"
 	"log/slog"
 	"os"
+	"strconv"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
@@ -13,21 +15,30 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 )
 
+const identityShardCount = 4
+
 type identityDDB struct {
-	Id              string `dynamodbav:"id"`
-	Type            string `dynamodbav:"type"`
-	SecondaryLookup string `dynamodbav:"secondary-lookup"`
+	Id                string `dynamodbav:"id"`
+	Type              string `dynamodbav:"type"`
+	ShardedType       string `dynamodbav:"sharded-type"`
+	SecondaryLookup   string `dynamodbav:"secondary-lookup"`
 	SecondaryLookupSk string `dynamodbav:"secondary-lookup-sk"`
-	Name            string `dynamodbav:"name"`
-	SecretHash      []byte `dynamodbav:"secret"`
-	CreatedAt       int64  `dynamodbav:"createdAt"`
-	UpdatedAt       int64  `dynamodbav:"updatedAt"`
+	Name              string `dynamodbav:"name"`
+	SecretHash        []byte `dynamodbav:"secret"`
+	CreatedAt         int64  `dynamodbav:"createdAt"`
+	UpdatedAt         int64  `dynamodbav:"updatedAt"`
+}
+
+func computeIdentityShard(id Id) string {
+	sum := crc32.ChecksumIEEE([]byte(id))
+	return "identity#" + strconv.Itoa(int(sum)%identityShardCount)
 }
 
 func convertToDB(identity *Identity) *identityDDB {
 	return &identityDDB{
 		Id:                string(identity.Id),
 		Type:              "identity",
+		ShardedType:       computeIdentityShard(identity.Id),
 		SecondaryLookup:   identity.Name,
 		SecondaryLookupSk: "identity",
 		Name:              identity.Name,
@@ -44,9 +55,10 @@ func key(id Id) map[string]types.AttributeValue {
 }
 
 type DynamoDBIdentityRepository struct {
-	Client                 *dynamodb.Client
-	Table                  *string
-	SecondaryLookupIndex   *string
+	Client               *dynamodb.Client
+	Table                *string
+	SecondaryLookupIndex *string
+	ShardedTypeIndex     *string
 }
 
 func NewIdentityRepository(cfg aws.Config) *DynamoDBIdentityRepository {
@@ -54,6 +66,7 @@ func NewIdentityRepository(cfg aws.Config) *DynamoDBIdentityRepository {
 		Client:               dynamodb.NewFromConfig(cfg),
 		Table:                aws.String(os.Getenv("ENTITIES_TABLE")),
 		SecondaryLookupIndex: aws.String("secondary-lookup-index"),
+		ShardedTypeIndex:     aws.String("sharded-type-index"),
 	}
 }
 
@@ -106,6 +119,48 @@ func (r *DynamoDBIdentityRepository) FindById(ctx context.Context, id Id) (*Iden
 	}
 
 	return entity, nil
+}
+
+func (r *DynamoDBIdentityRepository) FindAll(ctx context.Context) ([]*Identity, error) {
+	var result []*Identity
+
+	for i := 0; i < identityShardCount; i++ {
+		shard := "identity#" + strconv.Itoa(i)
+		keyEx := expression.Key("sharded-type").Equal(expression.Value(shard))
+		expr, err := expression.NewBuilder().WithKeyCondition(keyEx).Build()
+		if err != nil {
+			return nil, err
+		}
+
+		output, err := r.Client.Query(ctx, &dynamodb.QueryInput{
+			TableName:                 r.Table,
+			IndexName:                 r.ShardedTypeIndex,
+			KeyConditionExpression:    expr.KeyCondition(),
+			ExpressionAttributeNames:  expr.Names(),
+			ExpressionAttributeValues: expr.Values(),
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, item := range output.Items {
+			var dbEntity identityDDB
+			err = attributevalue.UnmarshalMap(item, &dbEntity)
+			if err != nil {
+				return nil, err
+			}
+
+			result = append(result, &Identity{
+				Id:         Id(dbEntity.Id),
+				Name:       dbEntity.Name,
+				SecretHash: dbEntity.SecretHash,
+				CreatedAt:  dbEntity.CreatedAt,
+				UpdatedAt:  dbEntity.UpdatedAt,
+			})
+		}
+	}
+
+	return result, nil
 }
 
 func (r *DynamoDBIdentityRepository) FindByName(ctx context.Context, name string) (*Identity, error) {


### PR DESCRIPTION
Add sharded-type index support for identities (CRC32 modulo 4, matching the existing oauth2 client pattern) and expose a `GET /v1/identities` endpoint to list all identities (authenticated).

## Changes
- Added `sharded-type` attribute to identity DynamoDB items via `computeIdentityShard()` in `repository.go`
- Added `ShardedTypeIndex` field to `DynamoDBIdentityRepository` and `FindAll(ctx)` querying all 4 shards on the existing `sharded-type-index` GSI
- Added `FindAll` to identity `Repository` interface and `Service`
- Added `GET /v1/identities` route and `List` handler returning `[]IdentityResponse`
- Updated test table setup with `sharded-type-index` GSI

## Verification
- Added `TestIdentityFindAllHappyPath` integration test (creates 3 identities, asserts list returns 3)
- Added `TestIdentityListEmptyReturnsEmptyList` handler test (empty table returns `[]`)
- Full test suite passes: `go test ./... -count=1`
- `go vet` and `golangci-lint` clean