### PR TITLE
fix: deduplicate React instances in Vite optimizer

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,6 +3,9 @@ import react, { reactCompilerPreset } from '@vitejs/plugin-react'
 import babel from '@rolldown/plugin-babel'
 
 export default defineConfig({
+  resolve: {
+    dedupe: ['react', 'react-dom'],
+  },
   plugins: [
     react(),
     babel({ presets: [reactCompilerPreset()] })


### PR DESCRIPTION
## Problem

Running the frontend produced an "Invalid hook call" error:

```
main.tsx:13 Invalid hook call. Hooks can only be called inside of the body of a function component.
@tanstack_react-router.js:707 Uncaught TypeError: Cannot read properties of null (reading 'useContext')
```

## Root Cause

Bun's workspace layout places packages under `node_modules/.bun/` cache directories. Vite's dependency optimizer was resolving `react` to different physical paths for the app code (`node_modules/react/`) versus `@tanstack/react-router` (`node_modules/.bun/react@19.2.6/`), causing it to **inline a separate copy of React** inside the TanStack Router optimized bundle. With two React instances, `resolveDispatcher()` returned `null` when hooks were called across instances.

## Fix

Added `resolve.dedupe: ['react', 'react-dom']` to `vite.config.ts`, which forces Vite to resolve all `react` and `react-dom` imports to a single instance regardless of symlink/cache path differences.