### PR TITLE
feat: add authn tests, fix user DI and authenticate bug

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -2,14 +2,12 @@ import { Database } from "bun:sqlite";
 import { staticPlugin } from "@elysiajs/static";
 import { Elysia } from "elysia";
 import { initalizeTables } from "./infra/db.migrator";
+import { authNRoutes } from "./modules/authn/authn.routes";
 import { userRoutes } from "./modules/user/user.routes";
-import { UserManagementService } from "./modules/user/user.service";
 
 const db: Database = new Database(":memory:");
 
 initalizeTables(db);
-
-const userService = new UserManagementService(db);
 
 const app = new Elysia()
 	.use(
@@ -19,7 +17,9 @@ const app = new Elysia()
 		}),
 	)
 
-	.use(userRoutes(userService))
+	.use(userRoutes(db))
+
+	.use(authNRoutes(db))
 
 	.get("/health", () => "ok")
 

--- a/backend/src/infra/db.migrator.ts
+++ b/backend/src/infra/db.migrator.ts
@@ -18,6 +18,18 @@ const tables: Table[] = [
     )
     `,
 	},
+	{
+		name: "sessions",
+		script: `
+     CREATE TABLE sessions (
+       id TEXT PRIMARY KEY,
+       owner_id TEXT KEY,
+       finger_print INTEGER,
+       created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+       expire_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+     )
+     `,
+	},
 ];
 
 export const initalizeTables = (db: Database) => {

--- a/backend/src/modules/authn/authn.errors.ts
+++ b/backend/src/modules/authn/authn.errors.ts
@@ -1,0 +1,25 @@
+export class AccountNotFoundError extends Error {}
+
+export class WrongPasswordError extends Error {
+	constructor(message = "Wrong password provided") {
+		super(message);
+	}
+}
+
+export class SessionExpiredError extends Error {
+	constructor(message = "Session expired") {
+		super(message);
+	}
+}
+
+export class InternalServerError extends Error {
+	constructor(message = "Internal server error") {
+		super(message);
+	}
+}
+
+export class FingerPrintMismach extends Error {
+	constructor(message = "Unable to authenticate with provided session") {
+		super(message);
+	}
+}

--- a/backend/src/modules/authn/authn.plugin.ts
+++ b/backend/src/modules/authn/authn.plugin.ts
@@ -1,0 +1,21 @@
+import type { Database } from "bun:sqlite";
+import Elysia from "elysia";
+import { userPlugin } from "../user/user.plugin";
+import { AuthenticationService } from "./authn.service";
+import { SessionStore } from "./session.store";
+
+export const authenticationPlugin = (db: Database) =>
+	new Elysia({ name: "module.authn" }).use(
+		userPlugin(db).decorate(({ userStore }) => {
+			const sessionStore = new SessionStore(db);
+			const authenticationService = new AuthenticationService(
+				sessionStore,
+				userStore,
+			);
+
+			return {
+				sessionStore,
+				authenticationService,
+			};
+		}),
+	);

--- a/backend/src/modules/authn/authn.routes.test.ts
+++ b/backend/src/modules/authn/authn.routes.test.ts
@@ -1,0 +1,201 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { Elysia } from "elysia";
+import { initalizeTables } from "../../infra/db.migrator";
+import { authNRoutes } from "./authn.routes";
+import { SessionStore } from "./session.store";
+
+const TEST_EMAIL = "alice@test.com";
+const TEST_PASSWORD = "my-secret-password";
+
+async function seedUser(db: Database): Promise<string> {
+	const secretHash = await Bun.password.hash(TEST_PASSWORD);
+	db.query(
+		"INSERT INTO users (id, email, secret_hash, created_at, updated_at) VALUES ($id, $email, $secretHash, $now, $now)",
+	).run({
+		$id: "seed-user-id",
+		$email: TEST_EMAIL,
+		$secretHash: secretHash,
+		$now: new Date().toISOString(),
+	});
+	return "seed-user-id";
+}
+
+type TestApp = ReturnType<typeof createApp>;
+
+function createApp() {
+	const db = new Database(":memory:");
+	initalizeTables(db);
+	const app = new Elysia().use(authNRoutes(db));
+	return { db, app };
+}
+
+describe("POST /login", () => {
+	let app: TestApp["app"];
+	let db: TestApp["db"];
+
+	afterEach(() => {
+		db?.close();
+	});
+
+	it("returns 200 and sets session cookie for valid credentials", async () => {
+		({ db, app } = createApp());
+		await seedUser(db);
+
+		const res = await app.handle(
+			new Request("http://localhost/login", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email: TEST_EMAIL, secret: TEST_PASSWORD }),
+			}),
+		);
+
+		expect(res.status).toBe(200);
+		const setCookie = res.headers.get("set-cookie");
+		expect(setCookie).toBeDefined();
+		expect(setCookie).toContain("session=");
+		expect(setCookie).toContain("HttpOnly");
+	});
+
+	it("returns 422 when email is missing", async () => {
+		({ db, app } = createApp());
+
+		const res = await app.handle(
+			new Request("http://localhost/login", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ secret: TEST_PASSWORD }),
+			}),
+		);
+
+		expect(res.status).toBe(422);
+	});
+
+	it("returns 422 when secret is missing", async () => {
+		({ db, app } = createApp());
+
+		const res = await app.handle(
+			new Request("http://localhost/login", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email: TEST_EMAIL }),
+			}),
+		);
+
+		expect(res.status).toBe(422);
+	});
+
+	it("returns 500 for invalid credentials", async () => {
+		({ db, app } = createApp());
+		await seedUser(db);
+
+		const res = await app.handle(
+			new Request("http://localhost/login", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email: TEST_EMAIL, secret: "wrong-password" }),
+			}),
+		);
+
+		expect(res.status).toBe(500);
+	});
+});
+
+describe("GET /authenticate", () => {
+	let app: TestApp["app"];
+	let db: TestApp["db"];
+
+	afterEach(() => {
+		db?.close();
+	});
+
+	it("returns 200 with session info for valid cookie", async () => {
+		({ db, app } = createApp());
+		const userId = await seedUser(db);
+
+		const loginRes = await app.handle(
+			new Request("http://localhost/login", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email: TEST_EMAIL, secret: TEST_PASSWORD }),
+			}),
+		);
+
+		const cookie = loginRes.headers.get("set-cookie")!;
+
+		const res = await app.handle(
+			new Request("http://localhost/authenticate", {
+				method: "GET",
+				headers: { cookie },
+			}),
+		);
+
+		expect(res.status).toBe(200);
+
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body.owner).toBe(userId);
+		expect(body.expireAt).toBeDefined();
+	});
+
+	it("returns 500 for missing session cookie", async () => {
+		({ db, app } = createApp());
+
+		const res = await app.handle(
+			new Request("http://localhost/authenticate", { method: "GET" }),
+		);
+
+		expect(res.status).toBe(500);
+	});
+
+	it("returns 500 for expired session", async () => {
+		({ db, app } = createApp());
+		await seedUser(db);
+
+		const sessionStore = new SessionStore(db);
+		await sessionStore.createSession({
+			id: "expired-session",
+			owner: "seed-user-id",
+			fingerPrint: Bun.hash.wyhash("test-agent"),
+			createdAt: new Date("2020-01-01T00:00:00Z"),
+			expireAt: new Date("2020-01-01T00:05:00Z"),
+		});
+
+		const res = await app.handle(
+			new Request("http://localhost/authenticate", {
+				method: "GET",
+				headers: {
+					cookie: "session=expired-session",
+					"user-agent": "test-agent",
+				},
+			}),
+		);
+
+		expect(res.status).toBe(500);
+	});
+
+	it("returns 500 for fingerprint mismatch", async () => {
+		({ db, app } = createApp());
+		await seedUser(db);
+
+		const sessionStore = new SessionStore(db);
+		await sessionStore.createSession({
+			id: "valid-session",
+			owner: "seed-user-id",
+			fingerPrint: Bun.hash.wyhash("original-agent"),
+			createdAt: new Date(),
+			expireAt: new Date(Date.now() + 5 * 60 * 1000),
+		});
+
+		const res = await app.handle(
+			new Request("http://localhost/authenticate", {
+				method: "GET",
+				headers: {
+					cookie: "session=valid-session",
+					"user-agent": "different-agent",
+				},
+			}),
+		);
+
+		expect(res.status).toBe(500);
+	});
+});

--- a/backend/src/modules/authn/authn.routes.ts
+++ b/backend/src/modules/authn/authn.routes.ts
@@ -1,0 +1,60 @@
+import type { Database } from "bun:sqlite";
+import { Elysia, t } from "elysia";
+import { SessionExpiredError } from "./authn.errors";
+import { authenticationPlugin } from "./authn.plugin";
+
+const AuthenticationDTO = t.Object({
+	owner: t.String(),
+	expireAt: t.String(),
+});
+
+export const authNRoutes = (db: Database) =>
+	new Elysia()
+		.use(authenticationPlugin(db))
+		.post(
+			"/login",
+			async ({ body, cookie: { session }, headers, authenticationService }) => {
+				const createdSession = await authenticationService.createSesssion({
+					email: body.email,
+					secret: body.secret,
+					rawFingerPrint: headers["User-Agent"] ?? "",
+				});
+
+				session.value = createdSession.id;
+				session.httpOnly = true;
+				session.maxAge = 300;
+			},
+			{
+				body: t.Object({
+					email: t.String(),
+					secret: t.String(),
+				}),
+				cookie: t.Cookie({
+					session: t.Optional(t.String()),
+				}),
+			},
+		)
+		.get(
+			"/authenticate",
+			async ({ cookie: { session }, headers, authenticationService }) => {
+				if (!session.value) {
+					throw new SessionExpiredError();
+				}
+
+				const userSession = await authenticationService.authenticate(
+					session.value,
+					headers["User-Agent"] ?? "",
+				);
+
+				return {
+					owner: userSession.owner,
+					expireAt: userSession.expireAt.toISOString(),
+				};
+			},
+			{
+				cookie: t.Cookie({
+					session: t.Optional(t.String()),
+				}),
+				response: AuthenticationDTO,
+			},
+		);

--- a/backend/src/modules/authn/authn.service.test.ts
+++ b/backend/src/modules/authn/authn.service.test.ts
@@ -1,0 +1,196 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { initalizeTables } from "../../infra/db.migrator";
+import { UserManagementStore } from "../user/user.store";
+import {
+	AccountNotFoundError,
+	FingerPrintMismach,
+	SessionExpiredError,
+	WrongPasswordError,
+} from "./authn.errors";
+import { AuthenticationService } from "./authn.service";
+import { SessionStore } from "./session.store";
+
+function createDb(): Database {
+	const db = new Database(":memory:");
+	initalizeTables(db);
+	return db;
+}
+
+const TEST_EMAIL = "alice@test.com";
+const TEST_PASSWORD = "my-secret-password";
+
+async function seedUser(userStore: UserManagementStore): Promise<string> {
+	const secretHash = await Bun.password.hash(TEST_PASSWORD);
+	const user = {
+		id: "seed-user-id",
+		email: TEST_EMAIL,
+		secretHash,
+		createdAt: new Date(),
+		updatedAt: new Date(),
+	};
+	await userStore.createUser(user);
+	return user.id;
+}
+
+describe("createSesssion", () => {
+	let db: Database;
+	let sessionStore: SessionStore;
+	let userStore: UserManagementStore;
+	let service: AuthenticationService;
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("creates a session with valid credentials", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+		await seedUser(userStore);
+
+		const session = await service.createSesssion({
+			email: TEST_EMAIL,
+			secret: TEST_PASSWORD,
+			rawFingerPrint: "test-agent",
+		});
+
+		expect(session).toBeDefined();
+		expect(session.id).toBeDefined();
+		expect(session.owner).toBe("seed-user-id");
+		expect(session.fingerPrint).toBe(Bun.hash.wyhash("test-agent"));
+		expect(session.createdAt).toBeInstanceOf(Date);
+		expect(session.expireAt).toBeInstanceOf(Date);
+		expect(session.expireAt.getTime() - session.createdAt.getTime()).toBe(
+			5 * 60 * 1000,
+		);
+	});
+
+	it("throws AccountNotFoundError for non-existent email", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+
+		expect(
+			service.createSesssion({
+				email: "doesnotexist@test.com",
+				secret: TEST_PASSWORD,
+				rawFingerPrint: "test-agent",
+			}),
+		).rejects.toThrow(AccountNotFoundError);
+	});
+
+	it("throws WrongPasswordError for wrong password", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+		await seedUser(userStore);
+
+		expect(
+			service.createSesssion({
+				email: TEST_EMAIL,
+				secret: "wrong-password",
+				rawFingerPrint: "test-agent",
+			}),
+		).rejects.toThrow(WrongPasswordError);
+	});
+
+	it("persists the session in the database", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+		await seedUser(userStore);
+
+		const session = await service.createSesssion({
+			email: TEST_EMAIL,
+			secret: TEST_PASSWORD,
+			rawFingerPrint: "test-agent",
+		});
+
+		const found = await sessionStore.getSession(session.id);
+		expect(found).toBeDefined();
+		expect(found?.id).toBe(session.id);
+	});
+});
+
+describe("authenticate", () => {
+	let db: Database;
+	let sessionStore: SessionStore;
+	let userStore: UserManagementStore;
+	let service: AuthenticationService;
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("returns session for valid id and matching fingerprint", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+		await seedUser(userStore);
+
+		const session = await service.createSesssion({
+			email: TEST_EMAIL,
+			secret: TEST_PASSWORD,
+			rawFingerPrint: "test-agent",
+		});
+
+		const result = await service.authenticate(session.id, "test-agent");
+		expect(result).toBeDefined();
+		expect(result.id).toBe(session.id);
+	});
+
+	it("throws SessionExpiredError for expired session", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+
+		const expiredSession = {
+			id: "expired-id",
+			owner: "some-user",
+			fingerPrint: Bun.hash.wyhash("test-agent"),
+			createdAt: new Date("2020-01-01T00:00:00Z"),
+			expireAt: new Date("2020-01-01T00:05:00Z"),
+		};
+		await sessionStore.createSession(expiredSession);
+
+		expect(
+			service.authenticate(expiredSession.id, "test-agent"),
+		).rejects.toThrow(SessionExpiredError);
+	});
+
+	it("throws SessionExpiredError for non-existent session", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+
+		expect(
+			service.authenticate("non-existent-id", "test-agent"),
+		).rejects.toThrow(SessionExpiredError);
+	});
+
+	it("throws FingerPrintMismach for mismatched fingerprint", async () => {
+		db = createDb();
+		userStore = new UserManagementStore(db);
+		sessionStore = new SessionStore(db);
+		service = new AuthenticationService(sessionStore, userStore);
+		await seedUser(userStore);
+
+		const session = await service.createSesssion({
+			email: TEST_EMAIL,
+			secret: TEST_PASSWORD,
+			rawFingerPrint: "original-agent",
+		});
+
+		expect(
+			service.authenticate(session.id, "different-agent"),
+		).rejects.toThrow(FingerPrintMismach);
+	});
+});

--- a/backend/src/modules/authn/authn.service.ts
+++ b/backend/src/modules/authn/authn.service.ts
@@ -1,0 +1,71 @@
+import { randomUUIDv7 } from "bun";
+import type { UserManagementStore } from "../user/user.store";
+import {
+	AccountNotFoundError,
+	FingerPrintMismach,
+	SessionExpiredError,
+	WrongPasswordError,
+} from "./authn.errors";
+import type { Session } from "./seession.entity";
+import type { SessionStore } from "./session.store";
+
+export interface LoginParams {
+	email: string;
+	secret: string;
+	rawFingerPrint: string;
+}
+
+export class AuthenticationService {
+	private readonly sessionStore: SessionStore;
+	private readonly userStore: UserManagementStore;
+
+	constructor(sessionStore: SessionStore, userStore: UserManagementStore) {
+		this.sessionStore = sessionStore;
+		this.userStore = userStore;
+	}
+
+	async createSesssion({
+		email,
+		secret,
+		rawFingerPrint,
+	}: LoginParams): Promise<Session> {
+		const user = await this.userStore.getUserByEmail(email);
+		if (user == null) {
+			throw new AccountNotFoundError(
+				"Account with provided email does not exists",
+			);
+		}
+
+		if (!(await Bun.password.verify(secret, user.secretHash))) {
+			throw new WrongPasswordError();
+		}
+
+		const createdAt = new Date();
+		const expireAt = new Date(createdAt.getTime() + 5 * 60 * 1000);
+
+		const newSession: Session = {
+			id: randomUUIDv7(),
+			owner: user.id,
+			fingerPrint: Bun.hash.wyhash(rawFingerPrint),
+			createdAt: createdAt,
+			expireAt: expireAt,
+		};
+
+		await this.sessionStore.createSession(newSession);
+
+		return newSession;
+	}
+
+	async authenticate(id: string, rawFingerPrint: string): Promise<Session> {
+		const session = await this.sessionStore.getSession(id);
+		if (session == null || session.expireAt < new Date()) {
+			throw new SessionExpiredError();
+		}
+
+		if (Number(session.fingerPrint) !== Number(Bun.hash.wyhash(rawFingerPrint))) {
+			throw new FingerPrintMismach();
+		}
+
+		return session;
+	}
+}

--- a/backend/src/modules/authn/seession.entity.ts
+++ b/backend/src/modules/authn/seession.entity.ts
@@ -1,0 +1,7 @@
+export interface Session {
+	id: string;
+	owner: string;
+	fingerPrint: bigint;
+	createdAt: Date;
+	expireAt: Date;
+}

--- a/backend/src/modules/authn/session.store.test.ts
+++ b/backend/src/modules/authn/session.store.test.ts
@@ -1,0 +1,63 @@
+import { Database } from "bun:sqlite";
+import { afterEach, describe, expect, it } from "bun:test";
+import { initalizeTables } from "../../infra/db.migrator";
+import type { Session } from "./seession.entity";
+import { SessionStore } from "./session.store";
+
+function createDb(): Database {
+	const db = new Database(":memory:");
+	initalizeTables(db);
+	return db;
+}
+
+function makeSession(overrides: Partial<Session> = {}): Session {
+	return {
+		id: "test-session-1",
+		owner: "test-user-1",
+		fingerPrint: 12345n,
+		createdAt: new Date("2025-01-01T00:00:00Z"),
+		expireAt: new Date("2025-01-01T00:05:00Z"),
+		...overrides,
+	};
+}
+
+describe("SessionStore", () => {
+	let db: Database;
+	let store: SessionStore;
+
+	afterEach(() => {
+		db.close();
+	});
+
+	it("creates a session and returns it", async () => {
+		db = createDb();
+		store = new SessionStore(db);
+
+		const input = makeSession();
+		const result = await store.createSession(input);
+
+		expect(result).toEqual(input);
+	});
+
+	it("getSession returns the session after creation", async () => {
+		db = createDb();
+		store = new SessionStore(db);
+
+		const input = makeSession();
+		await store.createSession(input);
+
+		const found = await store.getSession(input.id);
+		expect(found).toBeDefined();
+		expect(found?.id).toBe(input.id);
+		expect(found?.owner).toBe(input.owner);
+		expect(Number(found?.fingerPrint)).toBe(Number(input.fingerPrint));
+	});
+
+	it("getSession returns null for non-existent session", async () => {
+		db = createDb();
+		store = new SessionStore(db);
+
+		const found = await store.getSession("non-existent-id");
+		expect(found).toBeNull();
+	});
+});

--- a/backend/src/modules/authn/session.store.ts
+++ b/backend/src/modules/authn/session.store.ts
@@ -1,0 +1,43 @@
+import type { Database } from "bun:sqlite";
+import type { Session } from "./seession.entity";
+
+export class SessionStore {
+	private readonly db: Database;
+
+	constructor(db: Database) {
+		this.db = db;
+	}
+
+	async createSession(session: Session): Promise<Session> {
+		const insertQuery = this.db.query(
+			"INSERT INTO sessions (id, owner_id, finger_print, expire_at) VALUES ($id, $ownerId, $fingerPrint, $expireAt)",
+		);
+
+		insertQuery.run({
+			$id: session.id,
+			$ownerId: session.owner,
+			$fingerPrint: session.fingerPrint,
+			$expireAt: session.expireAt.toISOString(),
+		});
+
+		return session;
+	}
+
+	async getSession(id: string): Promise<Session | null> {
+		const row = this.db
+			.query(
+				"SELECT id, owner_id, finger_print, expire_at, created_at FROM sessions WHERE id = $id",
+			)
+			.get({ $id: id }) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+
+		return {
+			id: row.id as string,
+			owner: row.owner_id as string,
+			fingerPrint: row.finger_print as bigint,
+			createdAt: new Date(row.created_at as string),
+			expireAt: new Date(row.expire_at as string),
+		};
+	}
+}

--- a/backend/src/modules/user/user.plugin.ts
+++ b/backend/src/modules/user/user.plugin.ts
@@ -1,0 +1,15 @@
+import type { Database } from "bun:sqlite";
+import Elysia from "elysia";
+import { UserManagementService } from "./user.service";
+import { UserManagementStore } from "./user.store";
+
+export const userPlugin = (db: Database) =>
+	new Elysia({ name: "module.user" }).decorate(() => {
+		const userStore = new UserManagementStore(db);
+		const userService = new UserManagementService(userStore);
+
+		return {
+			userStore,
+			userService,
+		};
+	});

--- a/backend/src/modules/user/user.routes.test.ts
+++ b/backend/src/modules/user/user.routes.test.ts
@@ -3,15 +3,13 @@ import { afterEach, describe, expect, it } from "bun:test";
 import { Elysia } from "elysia";
 import { initalizeTables } from "../../infra/db.migrator";
 import { userRoutes } from "./user.routes";
-import { UserManagementService } from "./user.service";
 
 type TestApp = ReturnType<typeof createApp>;
 
 function createApp() {
 	const db = new Database(":memory:");
 	initalizeTables(db);
-	const service = new UserManagementService(db);
-	const app = new Elysia().use(userRoutes(service));
+	const app = new Elysia().use(userRoutes(db));
 	return { db, app };
 }
 

--- a/backend/src/modules/user/user.routes.ts
+++ b/backend/src/modules/user/user.routes.ts
@@ -1,15 +1,16 @@
+import type { Database } from "bun:sqlite";
 import { Elysia, t } from "elysia";
-import type { UserManagementService } from "./user.service";
+import { userPlugin } from "./user.plugin";
 
 const UserDTO = t.Object({
 	id: t.String(),
 	email: t.String(),
 });
 
-export const userRoutes = (userService: UserManagementService) =>
-	new Elysia({ prefix: "/users" }).post(
+export const userRoutes = (db: Database) =>
+	new Elysia({ prefix: "/users" }).use(userPlugin(db)).post(
 		"/",
-		async ({ body }) => {
+		async ({ body, userService }) => {
 			const user = await userService.createUser({
 				email: body.email,
 				secret: body.secret,

--- a/backend/src/modules/user/user.service.test.ts
+++ b/backend/src/modules/user/user.service.test.ts
@@ -20,7 +20,7 @@ describe("UserManagementService", () => {
 
 	it("creates a user with all required fields", async () => {
 		db = createDb();
-		service = new UserManagementService(db);
+		service = new UserManagementService(new UserManagementStore(db));
 
 		const user = await service.createUser({
 			email: "bob@test.com",
@@ -36,7 +36,7 @@ describe("UserManagementService", () => {
 
 	it("hashes the provided secret", async () => {
 		db = createDb();
-		service = new UserManagementService(db);
+		service = new UserManagementService(new UserManagementStore(db));
 
 		const secret = "super-secret-123";
 		const user = await service.createUser({ email: "bob@test.com", secret });
@@ -47,7 +47,7 @@ describe("UserManagementService", () => {
 
 	it("persists the user in the database", async () => {
 		db = createDb();
-		service = new UserManagementService(db);
+		service = new UserManagementService(new UserManagementStore(db));
 
 		const user = await service.createUser({
 			email: "bob@test.com",
@@ -55,7 +55,7 @@ describe("UserManagementService", () => {
 		});
 
 		const store = new UserManagementStore(db);
-		const found = await store.GetUser(user.id);
+		const found = await store.getUser(user.id);
 		expect(found).toBeDefined();
 		expect(found?.id).toBe(user.id);
 		expect(found?.email).toBe(user.email);

--- a/backend/src/modules/user/user.service.ts
+++ b/backend/src/modules/user/user.service.ts
@@ -1,7 +1,6 @@
-import type { Database } from "bun:sqlite";
 import { randomUUIDv7 } from "bun";
 import type { User } from "./user.entity";
-import { UserManagementStore as UserStore } from "./user.store";
+import type { UserManagementStore as UserStore } from "./user.store";
 
 export interface CreateUserParams {
 	email: string;
@@ -11,8 +10,8 @@ export interface CreateUserParams {
 export class UserManagementService {
 	private readonly store: UserStore;
 
-	constructor(db: Database) {
-		this.store = new UserStore(db);
+	constructor(userStore: UserStore) {
+		this.store = userStore;
 	}
 
 	async createUser({ email, secret }: CreateUserParams): Promise<User> {
@@ -28,6 +27,6 @@ export class UserManagementService {
 
 		console.log(`Creating user ${user.id} with email ${email}`);
 
-		return this.store.CreateUser(user);
+		return this.store.createUser(user);
 	}
 }

--- a/backend/src/modules/user/user.store.test.ts
+++ b/backend/src/modules/user/user.store.test.ts
@@ -34,7 +34,7 @@ describe("UserManagementStore", () => {
 		store = new UserManagementStore(db);
 
 		const input = makeUser();
-		const result = await store.CreateUser(input);
+		const result = await store.createUser(input);
 
 		expect(result).toEqual(input);
 	});
@@ -44,9 +44,9 @@ describe("UserManagementStore", () => {
 		store = new UserManagementStore(db);
 
 		const input = makeUser();
-		await store.CreateUser(input);
+		await store.createUser(input);
 
-		const found = await store.GetUser(input.id);
+		const found = await store.getUser(input.id);
 		expect(found).toBeDefined();
 		expect(found?.id).toBe(input.id);
 		expect(found?.email).toBe(input.email);
@@ -57,7 +57,29 @@ describe("UserManagementStore", () => {
 		db = createDb();
 		store = new UserManagementStore(db);
 
-		const found = await store.GetUser("non-existent-id");
+		const found = await store.getUser("non-existent-id");
+		expect(found).toBeNull();
+	});
+
+	it("getUserByEmail returns the user after creation", async () => {
+		db = createDb();
+		store = new UserManagementStore(db);
+
+		const input = makeUser();
+		await store.createUser(input);
+
+		const found = await store.getUserByEmail(input.email);
+		expect(found).toBeDefined();
+		expect(found?.id).toBe(input.id);
+		expect(found?.email).toBe(input.email);
+		expect(found?.secretHash).toBe(input.secretHash);
+	});
+
+	it("getUserByEmail returns null for non-existent email", async () => {
+		db = createDb();
+		store = new UserManagementStore(db);
+
+		const found = await store.getUserByEmail("doesnotexist@test.com");
 		expect(found).toBeNull();
 	});
 
@@ -65,10 +87,10 @@ describe("UserManagementStore", () => {
 		db = createDb();
 		store = new UserManagementStore(db);
 
-		await store.CreateUser(makeUser());
+		await store.createUser(makeUser());
 
 		expect(
-			store.CreateUser(
+			store.createUser(
 				makeUser({ id: "different-id", email: "alice@test.com" }),
 			),
 		).rejects.toThrow();

--- a/backend/src/modules/user/user.store.ts
+++ b/backend/src/modules/user/user.store.ts
@@ -8,7 +8,7 @@ export class UserManagementStore {
 		this.db = db;
 	}
 
-	async CreateUser(user: User): Promise<User> {
+	async createUser(user: User): Promise<User> {
 		const insertQuery = this.db.query(
 			"INSERT INTO users (id, email, secret_hash) VALUES ($id, $email, $secretHash)",
 		);
@@ -22,12 +22,30 @@ export class UserManagementStore {
 		return user;
 	}
 
-	async GetUser(id: string): Promise<User | null> {
+	async getUser(id: string): Promise<User | null> {
 		const row = this.db
 			.query(
 				"SELECT id, email, secret_hash, created_at, updated_at FROM users WHERE id = $id",
 			)
 			.get({ $id: id }) as Record<string, unknown> | undefined;
+
+		if (!row) return null;
+
+		return {
+			id: row.id as string,
+			email: row.email as string,
+			secretHash: row.secret_hash as string,
+			createdAt: new Date(row.created_at as string),
+			updatedAt: new Date(row.updated_at as string),
+		};
+	}
+
+	async getUserByEmail(email: string): Promise<User | null> {
+		const row = this.db
+			.query(
+				"SELECT id, email, secret_hash, created_at, updated_at FROM users WHERE email = $email",
+			)
+			.get({ $email: email }) as Record<string, unknown> | undefined;
 
 		if (!row) return null;
 


### PR DESCRIPTION
## Summary

Adds test coverage for the authn module (19 tests), fixes a **fingerprint type bug** that made `authenticate` always fail, and updates user module tests for the new dependency injection pattern.

## Changes

### Authn tests (3 new files)
- **`session.store.test.ts`** — `createSession`, `getSession` (found/not found)
- **`authn.service.test.ts`** — `createSesssion` (valid, wrong email, wrong password, persistence) + `authenticate` (valid, expired, non-existent, fingerprint mismatch)
- **`authn.routes.test.ts`** — `POST /login` (success + cookie, missing fields, invalid creds) + `GET /authenticate` (valid cookie, missing cookie, expired, fingerprint mismatch)

### Bug fix
- **`authn.service.ts`** — Fingerprint comparison was comparing `bigint !== number` (always true). Fixed with `Number()` coercion on both sides.

### User module test updates
- Updated constructor injection: `UserManagementService` now expects `UserStore` instead of `Database`
- Updated route signature: `userRoutes(db)` instead of `userRoutes(service)`
- Added `getUserByEmail` tests (found/not found)

## Test results
All 33 tests pass (14 user + 19 authn), 0 failures.