### PR TITLE
fix: map auth errors to proper HTTP status codes (401, 409)

### DIFF
--- a/backend/src/modules/authn/authn.routes.test.ts
+++ b/backend/src/modules/authn/authn.routes.test.ts
@@ -85,7 +85,7 @@ describe("POST /login", () => {
 		expect(res.status).toBe(422);
 	});
 
-	it("returns 500 for invalid credentials", async () => {
+	it("returns 401 for invalid credentials", async () => {
 		({ db, app } = createApp());
 		await seedUser(db);
 
@@ -97,7 +97,7 @@ describe("POST /login", () => {
 			}),
 		);
 
-		expect(res.status).toBe(500);
+		expect(res.status).toBe(401);
 	});
 });
 
@@ -137,17 +137,17 @@ describe("GET /authenticate", () => {
 		expect(body.expireAt).toBeDefined();
 	});
 
-	it("returns 500 for missing session cookie", async () => {
+	it("returns 401 for missing session cookie", async () => {
 		({ db, app } = createApp());
 
 		const res = await app.handle(
 			new Request("http://localhost/authenticate", { method: "GET" }),
 		);
 
-		expect(res.status).toBe(500);
+		expect(res.status).toBe(401);
 	});
 
-	it("returns 500 for expired session", async () => {
+	it("returns 401 for expired session", async () => {
 		({ db, app } = createApp());
 		await seedUser(db);
 
@@ -170,10 +170,10 @@ describe("GET /authenticate", () => {
 			}),
 		);
 
-		expect(res.status).toBe(500);
+		expect(res.status).toBe(401);
 	});
 
-	it("returns 500 for fingerprint mismatch", async () => {
+	it("returns 401 for fingerprint mismatch", async () => {
 		({ db, app } = createApp());
 		await seedUser(db);
 
@@ -196,6 +196,6 @@ describe("GET /authenticate", () => {
 			}),
 		);
 
-		expect(res.status).toBe(500);
+		expect(res.status).toBe(401);
 	});
 });

--- a/backend/src/modules/authn/authn.routes.ts
+++ b/backend/src/modules/authn/authn.routes.ts
@@ -1,6 +1,11 @@
 import type { Database } from "bun:sqlite";
 import { Elysia, t } from "elysia";
-import { SessionExpiredError } from "./authn.errors";
+import {
+	AccountNotFoundError,
+	FingerPrintMismach,
+	SessionExpiredError,
+	WrongPasswordError,
+} from "./authn.errors";
 import { authenticationPlugin } from "./authn.plugin";
 
 const AuthenticationDTO = t.Object({
@@ -11,6 +16,23 @@ const AuthenticationDTO = t.Object({
 export const authNRoutes = (db: Database) =>
 	new Elysia()
 		.use(authenticationPlugin(db))
+		.onError(({ error, set }) => {
+			if (
+				error instanceof AccountNotFoundError ||
+				error instanceof WrongPasswordError
+			) {
+				set.status = 401;
+				return { error: "Invalid credentials" };
+			}
+			if (error instanceof SessionExpiredError) {
+				set.status = 401;
+				return { error: "Session expired" };
+			}
+			if (error instanceof FingerPrintMismach) {
+				set.status = 401;
+				return { error: "Unauthorized" };
+			}
+		})
 		.post(
 			"/login",
 			async ({ body, cookie: { session }, headers, authenticationService }) => {

--- a/backend/src/modules/user/user.errors.ts
+++ b/backend/src/modules/user/user.errors.ts
@@ -1,0 +1,5 @@
+export class DuplicateEmailError extends Error {
+	constructor(message = "Email already exists") {
+		super(message);
+	}
+}

--- a/backend/src/modules/user/user.routes.test.ts
+++ b/backend/src/modules/user/user.routes.test.ts
@@ -39,6 +39,31 @@ describe("POST /users", () => {
 		expect(body.email).toBe("alice@test.com");
 	});
 
+	it("returns 409 for duplicate email", async () => {
+		({ db, app } = createApp());
+
+		await app.handle(
+			new Request("http://localhost/users", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email: "alice@test.com", secret: "pass123" }),
+			}),
+		);
+
+		const res = await app.handle(
+			new Request("http://localhost/users", {
+				method: "POST",
+				headers: { "content-type": "application/json" },
+				body: JSON.stringify({ email: "alice@test.com", secret: "pass456" }),
+			}),
+		);
+
+		expect(res.status).toBe(409);
+
+		const body = (await res.json()) as Record<string, unknown>;
+		expect(body.error).toBe("Email already exists");
+	});
+
 	it("returns 422 when email is missing", async () => {
 		({ db, app } = createApp());
 

--- a/backend/src/modules/user/user.routes.ts
+++ b/backend/src/modules/user/user.routes.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { Elysia, t } from "elysia";
+import { DuplicateEmailError } from "./user.errors";
 import { userPlugin } from "./user.plugin";
 
 const UserDTO = t.Object({
@@ -7,22 +8,35 @@ const UserDTO = t.Object({
 	email: t.String(),
 });
 
-export const userRoutes = (db: Database) =>
-	new Elysia({ prefix: "/users" }).use(userPlugin(db)).post(
-		"/",
-		async ({ body, userService }) => {
-			const user = await userService.createUser({
-				email: body.email,
-				secret: body.secret,
-			});
+const ErrorResponse = t.Object({ error: t.String() });
 
-			return user;
-		},
-		{
-			body: t.Object({
-				email: t.String(),
-				secret: t.String(),
-			}),
-			response: UserDTO,
-		},
-	);
+export const userRoutes = (db: Database) =>
+	new Elysia({ prefix: "/users" })
+		.use(userPlugin(db))
+		.onError(({ error, set }) => {
+			if (error instanceof DuplicateEmailError) {
+				set.status = 409;
+				return { error: error.message };
+			}
+		})
+		.post(
+			"/",
+			async ({ body, userService }) => {
+				const user = await userService.createUser({
+					email: body.email,
+					secret: body.secret,
+				});
+
+				return user;
+			},
+			{
+				body: t.Object({
+					email: t.String(),
+					secret: t.String(),
+				}),
+				response: {
+					200: UserDTO,
+					409: ErrorResponse,
+				},
+			},
+		);

--- a/backend/src/modules/user/user.service.test.ts
+++ b/backend/src/modules/user/user.service.test.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
 import { initalizeTables } from "../../infra/db.migrator";
+import { DuplicateEmailError } from "./user.errors";
 import { UserManagementService } from "./user.service";
 import { UserManagementStore } from "./user.store";
 
@@ -43,6 +44,17 @@ describe("UserManagementService", () => {
 
 		expect(user.secretHash).toBeDefined();
 		expect(user.secretHash).not.toBe(secret);
+	});
+
+	it("throws DuplicateEmailError for duplicate email", async () => {
+		db = createDb();
+		service = new UserManagementService(new UserManagementStore(db));
+
+		await service.createUser({ email: "bob@test.com", secret: "my-password" });
+
+		expect(
+			service.createUser({ email: "bob@test.com", secret: "other-password" }),
+		).rejects.toThrow(DuplicateEmailError);
 	});
 
 	it("persists the user in the database", async () => {

--- a/backend/src/modules/user/user.store.test.ts
+++ b/backend/src/modules/user/user.store.test.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { afterEach, describe, expect, it } from "bun:test";
 import { initalizeTables } from "../../infra/db.migrator";
 import type { User } from "./user.entity";
+import { DuplicateEmailError } from "./user.errors";
 import { UserManagementStore } from "./user.store";
 
 function createDb(): Database {
@@ -83,7 +84,7 @@ describe("UserManagementStore", () => {
 		expect(found).toBeNull();
 	});
 
-	it("throws when inserting a duplicate email", async () => {
+	it("throws DuplicateEmailError when inserting a duplicate email", async () => {
 		db = createDb();
 		store = new UserManagementStore(db);
 
@@ -93,6 +94,6 @@ describe("UserManagementStore", () => {
 			store.createUser(
 				makeUser({ id: "different-id", email: "alice@test.com" }),
 			),
-		).rejects.toThrow();
+		).rejects.toThrow(DuplicateEmailError);
 	});
 });

--- a/backend/src/modules/user/user.store.ts
+++ b/backend/src/modules/user/user.store.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import type { User } from "./user.entity";
+import { DuplicateEmailError } from "./user.errors";
 
 export class UserManagementStore {
 	private readonly db: Database;
@@ -9,17 +10,24 @@ export class UserManagementStore {
 	}
 
 	async createUser(user: User): Promise<User> {
-		const insertQuery = this.db.query(
-			"INSERT INTO users (id, email, secret_hash) VALUES ($id, $email, $secretHash)",
-		);
+		try {
+			const insertQuery = this.db.query(
+				"INSERT INTO users (id, email, secret_hash) VALUES ($id, $email, $secretHash)",
+			);
 
-		insertQuery.run({
-			$id: user.id,
-			$email: user.email,
-			$secretHash: user.secretHash,
-		});
+			insertQuery.run({
+				$id: user.id,
+				$email: user.email,
+				$secretHash: user.secretHash,
+			});
 
-		return user;
+			return user;
+		} catch (e) {
+			if ((e as Error)?.message?.includes("UNIQUE constraint")) {
+				throw new DuplicateEmailError();
+			}
+			throw e;
+		}
 	}
 
 	async getUser(id: string): Promise<User | null> {


### PR DESCRIPTION
### Problem

Auth errors (`AccountNotFoundError`, `WrongPasswordError`, `SessionExpiredError`, `FingerPrintMismach`) all returned **500** instead of proper status codes. Duplicate email registration returned a generic **500** from SQLite constraint violation.

### Changes

- **`authn.routes.ts`**: Added `onError` hook mapping auth errors to **401** with consistent JSON error responses
- **`user.errors.ts`**: New domain error `DuplicateEmailError`
- **`user.store.ts`**: Catches SQLite `UNIQUE constraint` and throws `DuplicateEmailError`
- **`user.routes.ts`**: Added `onError` hook mapping `DuplicateEmailError` to **409**
- **Tests**: Updated to expect correct status codes (401/409); added duplicate email test

### Error Mapping

| Error | Status | Body |
|---|---|---|
| `AccountNotFoundError` | 401 | `{ error: "Invalid credentials" }` |
| `WrongPasswordError` | 401 | `{ error: "Invalid credentials" }` |
| `SessionExpiredError` | 401 | `{ error: "Session expired" }` |
| `FingerPrintMismach` | 401 | `{ error: "Unauthorized" }` |
| `DuplicateEmailError` | 409 | `{ error: "Email already exists" }` |